### PR TITLE
fix: unattended SDLC runner cascade failure on diverged remote branch (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ Major-version bumps are reserved for explicit, manual maintenance milestones and
 
 ## [Unreleased]
 
+### Fixed
+
+- **Unattended SDLC runner cascade failure on diverged remote branches** (issue #102) — moves history reconciliation and push out of `/open-pr` into a new `/commit-push` skill, teaches the SDLC runner to distinguish `error_max_turns` from rate-limiting, threads structured bounce context between steps, and reconciles stale remote branches in `/start-issue` before re-picked cycles rebuild local.
+  - New `skills/commit-push/` bundle (`SKILL.md`, `references/rebase-and-push.md`, `references/version-bump-delegation.md`) — owns stage + version-bump + commit + fetch + rebase + push. Under unattended mode plus a completed rebase plus a safe `--force-with-lease=HEAD:$EXPECTED_SHA` check, pushes without prompting.
+  - `scripts/sdlc-runner.mjs` `matchErrorPattern` now parses `{"subtype":"error_max_turns"}` from stream-json **before** the rate-limit regex runs; `handleFailure` takes a `max_turns` branch that logs `"Turn budget exhausted..."` (never `"Rate limited"`) and falls through to the bounce path without a 60s sleep.
+  - `scripts/sdlc-runner.mjs` adds module-level `bounceContext` state plus `setBounceContext` / `clearBounceContext` helpers; `buildClaudeArgs` prepends a `## Bounce context` block with `from` / `reason` / `failedCheck` / `remoteCommitsSuperseded` hints to the receiving step's prompt, so the bounced-to subagent doesn't re-investigate divergence from scratch.
+  - `/open-pr` Steps 2 and 3 removed; Step 5 replaced with an ancestry check that exits non-zero on divergence with `DIVERGED: re-run commit-push to reconcile before creating PR` (consumed by the runner to bounce to `/commit-push`). `skills/open-pr/references/pr-body.md` Section 0 (pre-push race detection) and Section 1 (push rules) removed. `skills/open-pr/references/preflight.md` adds a Step 1c ancestry gate that mirrors the same sentinel.
+  - `/start-issue` adds Step 3.5 and `references/stale-remote-branch.md` — probes `git ls-remote` for an existing remote branch, tests `git merge-base --is-ancestor <remote-tip> origin/main`, and deletes stale tips via `git push origin --delete` (auto under unattended mode, interactive confirm otherwise) before `gh issue develop --checkout` runs.
+  - `scripts/sdlc-config.example.json` wires the `commitPush` step to `skill: "commit-push"` with `maxTurns: 20, timeoutMin: 8` (up from 15 / 5 to absorb the moved version-bump and rebase responsibilities). `createPR` stays at `maxTurns: 45` pending FR6 empirical re-evaluation across three green-path cycles.
+  - Regression tests in `scripts/__tests__/sdlc-runner.test.mjs` cover the `error_max_turns` → `max_turns` action, the no-sleep `handleFailure` branch, and the `bounceContext` injection / clear / override paths.
+
 ## [1.59.0] - 2026-04-23
 
 ### Added

--- a/scripts/__tests__/sdlc-runner.test.mjs
+++ b/scripts/__tests__/sdlc-runner.test.mjs
@@ -16,9 +16,11 @@ import { jest } from '@jest/globals';
 
 // Mock node:child_process
 const mockExecSync = jest.fn();
+const mockExecFileSync = jest.fn();
 const mockSpawn = jest.fn();
 jest.unstable_mockModule('node:child_process', () => ({
   execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
   spawn: mockSpawn,
 }));
 
@@ -744,6 +746,41 @@ describe('Error pattern matching', () => {
   it('returns null for empty string', () => {
     const result = matchErrorPattern('');
     expect(result).toBeNull();
+  });
+
+  // Issue #102 AC3: error_max_turns must match BEFORE the rate-limit regex so
+  // a max-turns exit never triggers the 60s "Rate limited" sleep.
+  describe('error_max_turns branch (issue #102 AC3, FR3)', () => {
+    it('matches {"subtype":"error_max_turns"} in stream-json → max_turns action', () => {
+      const streamOutput = [
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"Working..."}]}}',
+        '{"type":"result","subtype":"error_max_turns","session_id":"abc"}',
+      ].join('\n');
+      const result = matchErrorPattern(streamOutput);
+      expect(result).not.toBeNull();
+      expect(result.action).toBe('max_turns');
+      expect(result.pattern).toBe('error_max_turns');
+    });
+
+    it('error_max_turns wins over a co-occurring rate-limit substring', () => {
+      const streamOutput = [
+        '{"type":"assistant","message":{"content":[{"type":"text","text":"hit rate_limit once, retried"}]}}',
+        '{"type":"result","subtype":"error_max_turns","session_id":"abc"}',
+      ].join('\n');
+      const result = matchErrorPattern(streamOutput);
+      expect(result.action).toBe('max_turns');
+    });
+
+    it('returns max_turns from legacy single-JSON output', () => {
+      const single = JSON.stringify({ subtype: 'error_max_turns', session_id: 'x' });
+      const result = matchErrorPattern(single);
+      expect(result?.action).toBe('max_turns');
+    });
+
+    it('still returns wait for rate_limit without error_max_turns', () => {
+      const result = matchErrorPattern('rate_limit reached');
+      expect(result?.action).toBe('wait');
+    });
   });
 });
 
@@ -2688,8 +2725,8 @@ describe('performDeterministicVersionBump (#60)', () => {
   });
 });
 
-describe('createPR prompt includes version bump mandate (#60)', () => {
-  it('createPR prompt text mentions mandatory version bumping', () => {
+describe('createPR prompt contract post-FR1 (issue #102 AC4)', () => {
+  it('createPR prompt delegates the version bump to /commit-push and names the DIVERGED sentinel', () => {
     mockFs.existsSync.mockReturnValue(true);
     mockFs.readFileSync.mockReturnValue('skill content');
 
@@ -2699,8 +2736,9 @@ describe('createPR prompt includes version bump mandate (#60)', () => {
 
     const promptIdx = args.indexOf('-p') + 1;
     const prompt = args[promptIdx];
-    expect(prompt).toContain('MUST bump the version');
-    expect(prompt).toContain('mandatory');
+    expect(prompt).toContain('already been applied by /commit-push');
+    expect(prompt).toContain('DIVERGED: re-run commit-push to reconcile');
+    expect(prompt).not.toContain('MUST bump the version');
   });
 });
 
@@ -3346,3 +3384,141 @@ describe('skill path resolution (#88)', () => {
     });
   });
 });
+
+// ===========================================================================
+// Issue #102 — error_max_turns handleFailure branch + bounceContext injection
+// ===========================================================================
+
+describe('handleFailure: error_max_turns does not sleep (issue #102 AC3, FR3)', () => {
+  beforeEach(() => {
+    mockFs.existsSync.mockImplementation((p) => p === TEST_STATE_PATH);
+    mockFs.readFileSync.mockImplementation((p) => (
+      p === TEST_STATE_PATH
+        ? JSON.stringify({ ...defaultState(), currentIssue: 42, retries: {} })
+        : '{}'
+    ));
+    // git status clean, branch detection returns feature branch
+    mockExecSync.mockReturnValue('42-fix-divergence');
+  });
+
+  it('handleFailure with error_max_turns routes to bounce without a 60s rate-limit sleep', async () => {
+    const step = STEPS[7]; // createPR (step 8)
+    const state = { ...defaultState(), currentIssue: 42, currentBranch: '42-fix-divergence', retries: {} };
+    const stdout = '{"type":"result","subtype":"error_max_turns","session_id":"x"}';
+    const result = { exitCode: 1, stdout, stderr: '', duration: 10 };
+
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    const start = Date.now();
+    const outcome = await handleFailure(step, result, state);
+    const elapsed = Date.now() - start;
+
+    // The rate-limit branch sleeps 60_000 ms. If error_max_turns was routed correctly, elapsed ≪ 60s.
+    expect(elapsed).toBeLessThan(2_000);
+    expect(outcome).toBe('retry-previous');
+
+    const logged = logSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(logged).not.toMatch(/Rate limited\. Waiting 60s/);
+    expect(logged).toMatch(/Turn budget exhausted/);
+
+    logSpy.mockRestore();
+    mockExit.mockRestore();
+  });
+
+  it('handleFailure with error_max_turns populates bounceContext with reason=error_max_turns', async () => {
+    const step = STEPS[7];
+    const state = { ...defaultState(), currentIssue: 42, currentBranch: '42-fix-divergence', retries: {} };
+    const stdout = '{"type":"result","subtype":"error_max_turns","session_id":"x"}';
+    const result = { exitCode: 1, stdout, stderr: '', duration: 10 };
+
+    __test__.bounceContext = null;
+    const mockExit = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    await handleFailure(step, result, state);
+    mockExit.mockRestore();
+
+    const ctx = __test__.bounceContext;
+    expect(ctx).not.toBeNull();
+    expect(ctx.reason).toBe('error_max_turns');
+    expect(ctx.fromStepNumber).toBe(step.number);
+    expect(ctx.from).toBe(step.key);
+  });
+});
+
+describe('bounceContext injection into buildClaudeArgs (issue #102 AC5, FR4)', () => {
+  beforeEach(() => {
+    mockFs.existsSync.mockReturnValue(true);
+    mockFs.readFileSync.mockReturnValue('skill content');
+  });
+
+  it('prepends "## Bounce context" block when receiving step matches fromStepNumber - 1', () => {
+    __test__.bounceContext = {
+      from: 'createPR',
+      fromStepNumber: STEPS[7].number, // createPR = step 8
+      reason: 'error_max_turns',
+      failedCheck: 'turn budget exhausted',
+      divergenceHints: { remoteCommitsSuperseded: true, localCommitsAhead: true },
+    };
+
+    // Receiving step: commitPush (step 7) — skill-backed so the prompt is the
+    // default commit-push prompt.
+    const receivingStep = { ...STEPS[6], skill: 'commit-push' };
+    const state = { ...defaultState(), currentIssue: 42, currentBranch: '42-feature' };
+    const args = buildClaudeArgs(receivingStep, state);
+    const promptIdx = args.indexOf('-p') + 1;
+    const prompt = args[promptIdx];
+
+    expect(prompt).toContain('## Bounce context');
+    expect(prompt).toContain('from: createPR');
+    expect(prompt).toContain('reason: error_max_turns');
+    expect(prompt).toContain('failedCheck: turn budget exhausted');
+    expect(prompt).toContain('remoteCommitsSuperseded: true');
+
+    __test__.bounceContext = null;
+  });
+
+  it('does NOT inject the block when bounceContext is null (green path)', () => {
+    __test__.bounceContext = null;
+    const step = STEPS[0];
+    const args = buildClaudeArgs(step, defaultState());
+    const promptIdx = args.indexOf('-p') + 1;
+    expect(args[promptIdx]).not.toContain('## Bounce context');
+  });
+
+  it('does NOT inject when the receiving step does not match fromStepNumber - 1', () => {
+    __test__.bounceContext = {
+      from: 'createPR',
+      fromStepNumber: 8,
+      reason: 'precondition_failed',
+      failedCheck: 'branch pushed to remote',
+      divergenceHints: {},
+    };
+
+    // Unrelated step (not N-1): writeSpecs (step 3) — fromStepNumber + 1 = 9, not 3
+    const unrelatedStep = { ...STEPS[2], skill: 'write-spec' };
+    const state = { ...defaultState(), currentIssue: 42, currentBranch: '42-feature' };
+    const args = buildClaudeArgs(unrelatedStep, state);
+    const promptIdx = args.indexOf('-p') + 1;
+    expect(args[promptIdx]).not.toContain('## Bounce context');
+
+    __test__.bounceContext = null;
+  });
+
+  it('does NOT inject when an override prompt is supplied', () => {
+    __test__.bounceContext = {
+      from: 'createPR',
+      fromStepNumber: 8,
+      reason: 'precondition_failed',
+      failedCheck: 'foo',
+      divergenceHints: {},
+    };
+
+    const receivingStep = { ...STEPS[6], skill: 'commit-push' };
+    const args = buildClaudeArgs(receivingStep, defaultState(), { prompt: 'OVERRIDE' });
+    const promptIdx = args.indexOf('-p') + 1;
+    expect(args[promptIdx]).toBe('OVERRIDE');
+
+    __test__.bounceContext = null;
+  });
+});
+

--- a/scripts/sdlc-config.example.json
+++ b/scripts/sdlc-config.example.json
@@ -18,7 +18,7 @@
     "implement":    { "model": "opus",   "effort": "xhigh",  "maxTurns": 150, "timeoutMin": 30, "skill": "write-code" },
     "simplify":     { "model": "sonnet", "effort": "medium", "maxTurns": 60,  "timeoutMin": 15 },
     "verify":       { "model": "opus",   "effort": "high",   "maxTurns": 100, "timeoutMin": 20, "skill": "verify-code" },
-    "commitPush":   { "model": "haiku",                      "maxTurns": 15,  "timeoutMin": 5  },
+    "commitPush":   { "model": "haiku",                      "maxTurns": 20,  "timeoutMin": 8,  "skill": "commit-push" },
     "createPR":     { "model": "sonnet", "effort": "low",    "maxTurns": 45,  "timeoutMin": 5,  "skill": "open-pr" },
     "monitorCI":    { "model": "sonnet", "effort": "medium", "maxTurns": 60,  "timeoutMin": 20 },
     "merge":        { "model": "haiku",                      "maxTurns": 10,  "timeoutMin": 5  }

--- a/scripts/sdlc-runner.mjs
+++ b/scripts/sdlc-runner.mjs
@@ -14,7 +14,7 @@
  *   node sdlc-runner.mjs --config <path> --resume
  */
 
-import { spawn, execSync } from 'node:child_process';
+import { spawn, execSync, execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -146,6 +146,13 @@ const MAX_CONSECUTIVE_ESCALATIONS = 2;
 let consecutiveEscalations = 0;
 const escalatedIssues = new Set();
 let bounceCount = 0;
+
+// Structured context carried from a failed step to the step it bounces to.
+// Set at both bounce sites (runStep precondition fail, handleFailure
+// precondition fail), consumed by buildClaudeArgs exactly once, cleared after
+// the receiving step completes or a new cycle starts. Keeps the receiving
+// subagent from re-investigating divergence from scratch on every bounce.
+let bounceContext = null;
 
 // ---------------------------------------------------------------------------
 // Step definitions
@@ -976,9 +983,9 @@ function buildClaudeArgs(step, state, overrides = {}) {
 
     [STEP_NUMBER.verify]: `Verify the implementation for issue #${issue} on branch ${branch}. Fix any findings. Skill instructions are appended to your system prompt. Resolve relative file references from ${skillRoot}/.`,
 
-    [STEP_NUMBER.commitPush]: `Stage all changes, commit with a meaningful conventional-commit message summarizing the work for issue #${issue}, and push to the remote branch ${branch}. After pushing, verify the push succeeded by running git log origin/${branch}..HEAD --oneline — if any unpushed commits remain, or if git push reported an error, exit with a non-zero status code.`,
+    [STEP_NUMBER.commitPush]: `Commit and push the work for issue #${issue} on branch ${branch}. Stage changes, apply the version bump per the skill's procedure, write a conventional-commit message, fetch + reconcile with origin/main (rebase + --force-with-lease under unattended mode when local was rebased and the lease check is safe), and push. Skill instructions are appended to your system prompt. Resolve relative file references from ${skillRoot}/.`,
 
-    [STEP_NUMBER.createPR]: `Create a pull request for branch ${branch} targeting main for issue #${issue}. You MUST bump the version (Steps 2-3 of the skill) before creating the PR — this is mandatory and must not be skipped. Skill instructions are appended to your system prompt. Resolve relative file references from ${skillRoot}/.`,
+    [STEP_NUMBER.createPR]: `Create a pull request for branch ${branch} targeting main for issue #${issue}. The version bump has already been applied by /commit-push; your responsibility is preconditions + ancestry check + gh pr create + labels. If local is behind origin/main, exit non-zero with the sentinel "DIVERGED: re-run commit-push to reconcile before creating PR" on stdout — the runner will bounce control back to /commit-push. Skill instructions are appended to your system prompt. Resolve relative file references from ${skillRoot}/.`,
 
     [STEP_NUMBER.monitorCI]: [
       `Monitor CI for the PR on branch ${branch}. Follow these steps exactly:`,
@@ -1000,9 +1007,32 @@ function buildClaudeArgs(step, state, overrides = {}) {
     [STEP_NUMBER.merge]: `First verify CI is passing with gh pr checks. If the output contains "no checks reported", treat this as passing (the repository has no CI configured). If any check is failing, do NOT merge — report the failure and exit with a non-zero status. If all checks pass, merge the current PR to main and delete the remote branch ${branch}.`,
   };
 
+  let basePrompt = overrides.prompt || prompts[step.number];
+
+  // Prepend a structured bounce-context block when the current step is the
+  // one being bounced TO (i.e. the previous step failed and the runner
+  // re-entered step N-1). Keeps the receiving subagent from re-investigating
+  // the divergence from scratch — it can read `reason` / `failedCheck` /
+  // `remoteCommitsSuperseded` directly.
+  if (bounceContext && bounceContext.fromStepNumber === step.number + 1 && !overrides.prompt) {
+    const hints = bounceContext.divergenceHints || {};
+    const ctxBlock = [
+      '## Bounce context',
+      `from: ${bounceContext.from}`,
+      `reason: ${bounceContext.reason}`,
+      `failedCheck: ${bounceContext.failedCheck || '(none)'}`,
+      `remoteCommitsSuperseded: ${Boolean(hints.remoteCommitsSuperseded)}`,
+      hints.localCommitsAhead !== undefined ? `localCommitsAhead: ${Boolean(hints.localCommitsAhead)}` : null,
+      '',
+      'The previous step bounced to you. Use this context to act directly — do not re-investigate the divergence from scratch.',
+      '',
+    ].filter(l => l !== null).join('\n');
+    basePrompt = `${ctxBlock}\n${basePrompt}`;
+  }
+
   const claudeArgs = [
     '--model', overrides.model || MODEL,
-    '-p', overrides.prompt || prompts[step.number],
+    '-p', basePrompt,
     '--dangerously-skip-permissions',
     '--verbose',
     '--output-format', 'stream-json',
@@ -1135,6 +1165,14 @@ function matchErrorPattern(output) {
   for (const pattern of IMMEDIATE_ESCALATION_PATTERNS) {
     if (pattern.test(output)) return { action: 'escalate', pattern: pattern.source };
   }
+  // error_max_turns is semantically distinct from rate-limiting: the session
+  // exhausted its turn budget, not a rate cap. Detect via parsed JSON (stream
+  // result) before the rate-limit regex so the "Rate limited. Waiting 60s..."
+  // branch never fires for a max-turns exit.
+  const parsed = extractResultFromStream(output);
+  if (parsed?.subtype === 'error_max_turns') {
+    return { action: 'max_turns', pattern: 'error_max_turns' };
+  }
   if (RATE_LIMIT_PATTERN.test(output)) return { action: 'wait', pattern: 'rate_limit' };
   return null;
 }
@@ -1230,6 +1268,55 @@ function incrementBounceCount() {
   return false;
 }
 
+/**
+ * Cheap probe for remote-vs-local divergence hints. Returns an object with
+ * hints the receiving step can use to act without re-investigating. Purpose
+ * is a hint, not a full diagnosis — one git call, no loops.
+ */
+function probeDivergenceHints(branch) {
+  const hints = { remoteCommitsSuperseded: false };
+  if (!branch || branch === 'main' || branch === 'master') return hints;
+  // Pass the branch as an argv element (no shell) so a hostile ref name cannot
+  // smuggle metacharacters into the command. Git's own ref-format rules already
+  // forbid most shell metacharacters, but execFileSync removes the class of
+  // risk entirely.
+  const runGit = (args) => execFileSync('git', args, {
+    cwd: PROJECT_PATH, encoding: 'utf8', timeout: 10_000, stdio: ['ignore', 'pipe', 'ignore'],
+  }).trim();
+  try {
+    const remoteRef = `origin/${branch}`;
+    // Commits reachable from origin/<branch> but not from HEAD — i.e. remote
+    // has commits that are no longer in local history (typically after a
+    // rebase). If the remote branch does not exist this throws and we fall
+    // back to the default "false" hint.
+    const localAhead = runGit(['log', `${remoteRef}..HEAD`, '--oneline']);
+    const remoteAhead = runGit(['log', `HEAD..${remoteRef}`, '--oneline']);
+    hints.remoteCommitsSuperseded = remoteAhead.length > 0;
+    hints.localCommitsAhead = localAhead.length > 0;
+  } catch {
+    // Remote branch doesn't exist or git call failed — leave defaults.
+  }
+  return hints;
+}
+
+/**
+ * Capture the current bounce state so the receiving step sees it once via
+ * buildClaudeArgs. `reason` is one of 'precondition_failed' | 'error_max_turns'.
+ */
+function setBounceContext({ fromStep, reason, failedCheck, branch }) {
+  bounceContext = {
+    from: fromStep.key,
+    fromStepNumber: fromStep.number,
+    reason,
+    failedCheck: failedCheck || null,
+    divergenceHints: probeDivergenceHints(branch),
+  };
+}
+
+function clearBounceContext() {
+  bounceContext = null;
+}
+
 // ---------------------------------------------------------------------------
 // Step outcome idempotency detection
 // ---------------------------------------------------------------------------
@@ -1296,7 +1383,13 @@ async function handleFailure(step, result, state) {
     return 'escalated';
   }
 
-  if (patternMatch?.action === 'wait') {
+  if (patternMatch?.action === 'max_turns') {
+    // error_max_turns is a turn-budget exhaustion, not rate-limiting. Skip the
+    // 60s sleep and fall through to the bounce path so the previous step can
+    // re-establish a clean starting state (with structured bounce context).
+    log(`Turn budget exhausted on Step ${step.number} (${step.key}). Bouncing to previous step.`);
+    log(`[STATUS] Step ${step.number} (${step.key}) exhausted turn budget. Bouncing to previous step.`);
+  } else if (patternMatch?.action === 'wait') {
     log('Rate limited. Waiting 60s before retry...');
     log(`[STATUS] Rate limited on Step ${step.number}. Waiting 60s...`);
     await sleep(60_000);
@@ -1306,12 +1399,14 @@ async function handleFailure(step, result, state) {
   if (step.number > 1) {
     const prevStep = STEPS[step.number - 2];
     const preconds = validatePreconditions(step, state);
-    if (!preconds.ok) {
+    if (!preconds.ok || patternMatch?.action === 'max_turns') {
       if (incrementBounceCount()) {
         await escalate(step, `Bounce loop: ${bounceCount} step-back transitions exceed threshold ${MAX_BOUNCE_RETRIES}`, output);
         return 'escalated';
       }
-      const failedCheck = preconds.failedCheck || preconds.reason;
+      const failedCheck = preconds.failedCheck || preconds.reason || (patternMatch?.action === 'max_turns' ? 'turn budget exhausted' : null);
+      const reason = patternMatch?.action === 'max_turns' ? 'error_max_turns' : 'precondition_failed';
+      setBounceContext({ fromStep: step, reason, failedCheck, branch: state.currentBranch });
       log(`Step ${step.number} (${step.key}) precondition failed: "${failedCheck}". Bouncing to Step ${prevStep.number} (${prevStep.key}). (bounce ${bounceCount}/${MAX_BOUNCE_RETRIES})`);
       log(`[STATUS] Step ${step.number} (${step.key}) bounced to Step ${prevStep.number} (${prevStep.key}). Precondition failed: "${failedCheck}". (bounce ${bounceCount}/${MAX_BOUNCE_RETRIES})`);
       return 'retry-previous';
@@ -2061,6 +2156,7 @@ async function runStep(step, state) {
         await escalate(prevStep, `Bounce loop: ${bounceCount} step-back transitions exceed threshold ${MAX_BOUNCE_RETRIES} (precondition: ${failedCheck})`);
         return 'escalated';
       }
+      setBounceContext({ fromStep: step, reason: 'precondition_failed', failedCheck, branch: state.currentBranch });
       log(`Step ${step.number} (${step.key}) bounced to Step ${prevStep.number} (${prevStep.key}). Precondition failed: "${failedCheck}". (bounce ${bounceCount}/${MAX_BOUNCE_RETRIES})`);
       log(`[STATUS] Step ${step.number} (${step.key}) bounced to Step ${prevStep.number} (${prevStep.key}). Precondition failed: "${failedCheck}". (bounce ${bounceCount}/${MAX_BOUNCE_RETRIES})`);
       // Increment retry for the previous step
@@ -2204,6 +2300,7 @@ async function runStep(step, state) {
     }
 
     log(`[STATUS] Step ${step.number} (${step.key}) complete.${result.duration > 60 ? ` (${Math.round(result.duration / 60)}min)` : ''}`);
+    clearBounceContext();
     return 'ok';
   }
 
@@ -2394,6 +2491,7 @@ async function main() {
     if (SINGLE_ISSUE_NUMBER) break;
 
     // After a full cycle (or escalation), reset for next iteration
+    clearBounceContext();
     state = readState();
     if (state.currentStep === 0) {
       // Clean cycle completion or escalation reset — check for more issues
@@ -2426,6 +2524,7 @@ const __test__ = {
     consecutiveEscalations = 0;
     escalatedIssues.clear();
     SINGLE_ISSUE_NUMBER = null;
+    bounceContext = null;
   },
   setConfig(cfg) {
     PROJECT_PATH = cfg.projectPath ?? PROJECT_PATH;
@@ -2451,6 +2550,8 @@ const __test__ = {
   get skillRootSource() { return SKILL_ROOT_SOURCE; },
   get bounceCount() { return bounceCount; },
   set bounceCount(v) { bounceCount = v; },
+  get bounceContext() { return bounceContext; },
+  set bounceContext(v) { bounceContext = v; },
   get consecutiveEscalations() { return consecutiveEscalations; },
   set consecutiveEscalations(v) { consecutiveEscalations = v; },
   get escalatedIssues() { return escalatedIssues; },
@@ -2471,6 +2572,9 @@ export {
   extractStateFromStep,
   matchErrorPattern,
   incrementBounceCount,
+  setBounceContext,
+  clearBounceContext,
+  probeDivergenceHints,
   defaultState,
   validateConfig,
   getConfigObject,

--- a/skills/commit-push/SKILL.md
+++ b/skills/commit-push/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: commit-push
+description: "Stage, bump version, commit with conventional-commit message, fetch, rebase if diverged, and push the feature branch. Use when user says 'commit and push', 'push my changes', 'push to remote', 'commit the work', 'ship the commit', or when the SDLC runner invokes the commitPush step. Do NOT use for creating PRs, merging, or verifying code. Handles force-with-lease safely under unattended mode after a rebase. Seventh step in the SDLC pipeline — follows /verify-code and precedes /open-pr."
+disable-model-invocation: true
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash(git:*), Bash(gh:*), AskUserQuestion
+model: haiku
+---
+
+# Commit and Push
+
+Stage implementation work, bump the project version, write a conventional-commit message, reconcile with the remote base branch if necessary, and push the feature branch. Owns history reconciliation for the pipeline so `/open-pr` can stay scoped to PR creation.
+
+Read `../../references/legacy-layout-gate.md` when the workflow starts — the gate aborts before Step 1 if the project still keeps SDLC artifacts under `.claude/steering/` or `.claude/specs/` (the current Claude Code release refuses to Edit/Write there).
+
+Read `../../references/unattended-mode.md` when the workflow starts — the sentinel pre-approves the force-with-lease branch in Step 6 and actively suppresses the interactive confirmation prompt used in manual mode.
+
+Read `../../references/feature-naming.md` when locating the spec directory for the issue and no `{feature-name}` is already known — the reference covers the `feature-{slug}` / `bug-{slug}` convention and the `**Issues**` frontmatter fallback chain.
+
+Read `../../references/versioning.md` when you need the versioning invariants — single-source-of-truth (`VERSION`), major-bumps-are-manual, dual-file update, CHANGELOG conventions, and the epic-child downgrade rule.
+
+Read `../../references/steering-schema.md` when reading `steering/tech.md` for the `## Versioning` bump matrix or stack-specific versioned-files table — `tech.md` is the authoritative source for project-specific bump behaviour.
+
+Read `references/version-bump-delegation.md` when a `VERSION` file exists at the project root and the issue does not carry the `spike` label — the reference points at the canonical bump-matrix lookup and artifact-update procedure.
+
+Read `references/rebase-and-push.md` when `git fetch` shows the remote has diverged from local — the reference covers ancestry detection, rebase-on-divergence, the force-with-lease safety envelope, and conflict handling.
+
+## Prerequisites
+
+1. Implementation commits or uncommitted work exist on the current feature branch.
+2. The working tree may be dirty — this skill stages and commits it.
+3. `origin` remote is reachable for fetch and push.
+
+---
+
+## Workflow
+
+### Step 1: Stage Changes
+
+Stage all tracked and untracked changes (excluding SDLC runner artifacts already covered by `.gitignore`):
+
+```bash
+git add -A
+```
+
+If `git status --porcelain` (after staging) is empty AND `git log main..HEAD --oneline` is also empty, there is nothing to commit or push — exit 0 with the note `No changes to commit or push`.
+
+### Step 2: Apply Version Bump
+
+Read `references/version-bump-delegation.md`. Apply the version bump (unless spike-labelled or no `VERSION` file exists). Stage the updated version artifacts (`VERSION`, `CHANGELOG.md`, and any stack-specific files from the `## Versioning` table in `steering/tech.md`).
+
+### Step 3: Commit
+
+Write a conventional-commit message summarising the issue's implementation (e.g., `feat: <short description> (#N)` or `fix: <short description> (#N)`). If the working tree is clean but a version bump was applied in Step 2, commit the bump with `chore: bump version to {new_version}`. If there are implementation changes to commit, combine them into a single commit; otherwise commit the bump separately.
+
+```bash
+git commit -m "feat: <description> (#N)"
+```
+
+### Step 4: Fetch + Ancestry Check
+
+```bash
+git fetch origin
+git merge-base --is-ancestor origin/{base-branch} HEAD
+```
+
+Base branch is `main` unless steering/config specifies otherwise.
+
+- **Exit code 0**: local contains every commit in `origin/{base-branch}` — no rebase needed, proceed to Step 6.
+- **Non-zero**: local does not contain `origin/{base-branch}`'s tip — proceed to Step 5.
+
+### Step 5: Rebase on Divergence
+
+Read `references/rebase-and-push.md` — the reference covers the rebase command, re-computing the version bump against the new baseline, amending the bump commit if the new version differs, and conflict handling.
+
+Mark this session as `rebased = true` so Step 6 takes the force-with-lease branch.
+
+### Step 6: Push
+
+The push branches on four signals: remote tracking state, whether Step 5 rebased, the `.claude/unattended-mode` sentinel, and the force-with-lease safety check.
+
+1. **No remote tracking branch** (first push for this branch):
+   ```bash
+   git push -u origin HEAD
+   ```
+2. **Tracking exists, `rebased === false`**, fast-forward:
+   ```bash
+   git push
+   ```
+3. **Tracking exists, `rebased === true`, `.claude/unattended-mode` sentinel present, safe lease**:
+   ```bash
+   git push --force-with-lease=HEAD:$EXPECTED_SHA
+   ```
+   Where `$EXPECTED_SHA` is the `origin/{branch}` SHA recorded **before** the rebase (the `git fetch` output). The safe-lease check fails if the remote advanced between the fetch and the push — this is the safety envelope.
+4. **Tracking exists, `rebased === true`, sentinel absent** (interactive mode):
+   Use `AskUserQuestion` with options `[1] Force-push with lease` and `[2] Abort — resolve manually`. Proceed with the user's selection. Abort exits non-zero.
+
+Read `references/rebase-and-push.md` § "Safe lease" for the exact `--force-with-lease` invocation and the recovery path when the lease check rejects the push.
+
+### Step 7: Verify Push Success
+
+After the push returns, verify no unpushed commits remain:
+
+```bash
+git log origin/{branch}..HEAD --oneline
+```
+
+If the output is non-empty OR `git push` reported an error, exit with a non-zero status code. The SDLC runner's post-step push-validation gate reads the same signal.
+
+---
+
+## Output
+
+```
+--- Commit and Push Complete ---
+Branch: {branch}
+Commits pushed: {N}
+Version bump: {old → new | none}
+Rebased: {yes | no}
+Force-with-lease used: {yes | no}
+
+[If `.claude/unattended-mode` does NOT exist]: Next step: Run `/open-pr #N` to open a pull request.
+[If `.claude/unattended-mode` exists]: Done. Awaiting orchestrator.
+```
+
+---
+
+## Integration with SDLC Workflow
+
+```
+/draft-issue  →  /start-issue #N  →  /write-spec #N  →  /write-code #N  →  /simplify  →  /verify-code #N  →  /commit-push  →  /open-pr #N  →  /address-pr-comments #N
+                                                                                                                  ▲ You are here
+```
+
+The commit-push skill is invoked by the SDLC runner as the `commitPush` step. Its postcondition — `origin/{branch}` matches `HEAD` after push — is the precondition for `/open-pr`, which checks ancestry with `origin/main` but no longer pushes.

--- a/skills/commit-push/references/rebase-and-push.md
+++ b/skills/commit-push/references/rebase-and-push.md
@@ -1,0 +1,93 @@
+# Rebase on Divergence and Safe Force-Push
+
+**Consumed by**: `commit-push` Steps 5 (rebase on divergence) and 6 (push), including the force-with-lease branch under unattended mode.
+
+Handles two cases that must resolve without human input when the SDLC runner is in unattended mode:
+
+- **Epic-child race**: a sibling PR merged to `origin/main` while this branch was being implemented — local needs to pick up the newer base.
+- **Stale remote tip**: an earlier cycle pushed commits that are no longer in local history after rebase.
+
+---
+
+## Step 5: Rebase
+
+Before rebasing, record the remote tip so Step 6's force-with-lease can use it:
+
+```bash
+EXPECTED_SHA=$(git rev-parse origin/{branch})
+```
+
+Then rebase local onto the advanced base branch:
+
+```bash
+git pull --rebase origin {base-branch}
+```
+
+Base branch is `main` unless `steering/tech.md` or the runner config specifies otherwise.
+
+### Re-compute the version bump against the new baseline
+
+If Step 2 committed a version bump, the rebase may have pulled in a sibling's bump that changes the baseline. Re-apply the bump logic from `references/version-bump-delegation.md`:
+
+1. Re-read the current version from `VERSION` after the rebase completes.
+2. Apply the same `siblingClass`-aware bump classification.
+3. If the re-computed version differs from what Step 3 committed, amend the version-bump commit:
+   ```bash
+   git checkout VERSION CHANGELOG.md [stack-specific files]
+   # redo version artifact updates against the new baseline
+   git add VERSION CHANGELOG.md [stack-specific files]
+   git commit --amend -m "chore: bump version to {re-computed-new-version}" --no-edit
+   ```
+
+### Conflict handling
+
+If the rebase produces conflicts in `VERSION`, `plugin.json`, `marketplace.json`, `package.json`, or `CHANGELOG.md`, abort:
+
+- **Interactive mode**: print the conflict list and the abort message below, then stop.
+- **Unattended mode**: emit the escalation sentinel and exit non-zero — do NOT `git rebase --abort` silently; leave the conflict state for the operator.
+
+Abort message:
+
+```
+ERROR: rebase conflict in version file(s): {file-list}. Resolve manually and re-run /commit-push. Force-push never overwrites unresolved conflicts.
+```
+
+Unattended escalation:
+
+```
+ESCALATION: commit-push — rebase conflict in version file(s): {file-list}. Resolve manually and re-run.
+```
+
+Record `rebased = true` before returning to Step 6 so the push takes the force-with-lease branch.
+
+---
+
+## Step 6: Safe force-push branch
+
+When `rebased === true` AND `.claude/unattended-mode` exists, push with `--force-with-lease` bound to the `EXPECTED_SHA` captured **before** the rebase:
+
+```bash
+git push --force-with-lease=HEAD:$EXPECTED_SHA
+```
+
+### What makes the lease safe
+
+`--force-with-lease=HEAD:$EXPECTED_SHA` tells git: "force-push only if `origin/{branch}` still points at `$EXPECTED_SHA`." Between our fetch and our push:
+
+- **Nobody else pushed**: `origin/{branch}` still matches `$EXPECTED_SHA` → push proceeds with the rewrite. Safe.
+- **Someone else pushed**: `origin/{branch}` has advanced → push is rejected non-fast-forward. The force-with-lease aborts instead of overwriting the other person's work. Safe by construction.
+
+The runner interprets the "rejected — stale info" error as a recoverable condition (re-fetch and retry).
+
+### Plain `git push` is wrong here
+
+After a rebase the commit SHAs on local diverge from what the remote still holds. A plain `git push` is non-fast-forward and gets rejected. A plain `git push --force` would blindly overwrite — unsafe if anyone pushed to this branch between our fetch and push. `--force-with-lease` is the only correct push after a rebase.
+
+### Interactive fallback
+
+When `.claude/unattended-mode` is absent (interactive mode), do NOT take the force-with-lease branch automatically. Use `AskUserQuestion` with two options:
+
+- `[1] Force-push with lease — overwrite the remote feature branch`
+- `[2] Abort — investigate the divergence manually`
+
+If the user picks `[1]`, run the same `git push --force-with-lease=HEAD:$EXPECTED_SHA` command. If `[2]`, exit non-zero without pushing.

--- a/skills/commit-push/references/version-bump-delegation.md
+++ b/skills/commit-push/references/version-bump-delegation.md
@@ -1,0 +1,38 @@
+# Version-Bump Delegation
+
+**Consumed by**: `commit-push` Step 2 (apply version bump).
+
+The version-bump logic — classification matrix, epic-child sibling-aware downgrade, artifact updates, CHANGELOG roll — lives in one place and is read from both `/open-pr` (historically) and `/commit-push` (after FR1). This reference exists so `commit-push`'s SKILL.md can point at the canonical procedure without duplicating it.
+
+## Canonical procedure
+
+Read `../../open-pr/references/version-bump.md` — the reference covers:
+
+- Spike handling (skip bump entirely for `spike`-labelled issues; emit `Type: Spike research (no version bump)` in the PR body).
+- `VERSION` read and semver validation.
+- Label-matrix lookup in `steering/tech.md` → `## Versioning` → `### Version Bump Classification`.
+- `major_requested` override (set by `/open-pr` Step 0; in commit-push context the `--major` flag is not available and this override is always false).
+- Epic-child sibling enumeration, `closedByPullRequestsReferences` inspection, and the `intermediate` / `final` downgrade rule.
+- Epic-closure warning (interactive confirmation in manual mode; escalation in unattended mode).
+- Stack-specific versioned-files table from `steering/tech.md` → `## Versioning`.
+- CHANGELOG `[Unreleased]` roll under the new version heading, with partial-delivery annotation for intermediate epic children.
+- Commit message shape: `chore: bump version to {new_version}`.
+
+## Differences between `/open-pr` and `/commit-push` invocations
+
+| Aspect | `/open-pr` historical behaviour | `/commit-push` behaviour |
+|--------|----------------------------------|--------------------------|
+| `--major` flag | Honours `/open-pr #N --major` | Not applicable — `/commit-push` has no argument surface |
+| Call site | Runs inside the skill immediately before `gh pr create` | Runs after staging, before the commit, so the bump is part of the implementation commit (or its own `chore: bump` commit when implementation is clean) |
+| Unattended escalation | Escalates on the epic-closure warning | Same — escalation semantics are identical |
+
+## What this reference deliberately omits
+
+- No re-statement of the bump matrix — `steering/tech.md` is the single source of truth and `../../open-pr/references/version-bump.md` is the single reader.
+- No independent artifact-update procedure — identical logic must not diverge between call sites. The one procedure lives in `version-bump.md`.
+- No duplicated spike handling — the `spike = true` check at the top of `version-bump.md` applies to both call sites.
+
+## Out of scope for this reference
+
+- The push mechanics, including the force-with-lease envelope — see `rebase-and-push.md`.
+- CI monitoring and PR creation — owned by `/open-pr` and the runner's `monitorCI` step.

--- a/skills/open-pr/SKILL.md
+++ b/skills/open-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-pr
-description: "Create a pull request with spec-driven summary, linking GitHub issue and spec documents. Use when user says 'create PR', 'open pull request', 'submit for review', 'push for review', 'ready to merge', 'make a PR for issue #N', 'how do I create a PR', 'how do I open a pull request', or 'ship this'. Do NOT use for implementing code, verifying specs, or creating issues. Handles version bumping, changelog updates, and links specs and acceptance criteria. Sixth step in the SDLC pipeline — follows /verify-code and precedes /address-pr-comments."
+description: "Create a pull request with spec-driven summary, linking GitHub issue and spec documents. Use when user says 'create PR', 'open pull request', 'submit for review', 'push for review', 'ready to merge', 'make a PR for issue #N', 'how do I create a PR', 'how do I open a pull request', or 'ship this'. Do NOT use for implementing code, verifying specs, creating issues, or committing/pushing — version bumping and pushing live in /commit-push. Links specs and acceptance criteria into the PR body. Eighth step in the SDLC pipeline — follows /commit-push and precedes /address-pr-comments."
 argument-hint: "[#issue-number] [--major]"
 disable-model-invocation: true
 allowed-tools: Read, Glob, Grep, Write, Edit, Bash(gh:*), Bash(git:*), Bash(sleep:*), AskUserQuestion
@@ -14,11 +14,11 @@ Create a pull request with a spec-driven summary that links to the GitHub issue 
 
 Read `../../references/legacy-layout-gate.md` when the workflow starts — the gate aborts before Step 1 if the project still keeps SDLC artifacts under `.claude/steering/` or `.claude/specs/`.
 
-Read `../../references/unattended-mode.md` when the workflow starts — the sentinel pre-approves the Step 2 version-bump confirmation and actively suppresses the Step 7 CI-monitor prompt (the runner owns CI monitoring and merging).
+Read `../../references/unattended-mode.md` when the workflow starts — the sentinel actively suppresses the Step 7 CI-monitor prompt (the runner owns CI monitoring and merging). Version-bump and push duties have moved to `/commit-push` as of FR1; this skill no longer owns a human-review gate for version bumping.
 
 Read `../../references/feature-naming.md` when locating the spec directory for the issue and no `{feature-name}` is already known — the reference covers the `feature-{slug}` / `bug-{slug}` convention and the `**Issues**` frontmatter fallback chain.
 
-Read `../../references/versioning.md` when you need the versioning invariants — single-source-of-truth (`VERSION`), major-bumps-are-manual, dual-file update (plugin.json + marketplace.json), CHANGELOG conventions, and the epic-child downgrade rule.
+Read `../../references/versioning.md` when you need the versioning invariants — single-source-of-truth (`VERSION`), major-bumps-are-manual, dual-file update (plugin.json + marketplace.json), CHANGELOG conventions, and the epic-child downgrade rule. This skill reads the version artifacts (`VERSION`, `CHANGELOG.md`) to populate the PR body but does NOT modify them — `/commit-push` owns the bump itself.
 
 Read `../../references/steering-schema.md` when reading `steering/tech.md` for the `## Versioning` bump matrix or stack-specific versioned-files table — `tech.md` is the authoritative source for project-specific bump behaviour.
 
@@ -26,7 +26,7 @@ Read `../../references/steering-schema.md` when reading `steering/tech.md` for t
 
 1. Implementation is complete (all tasks from `tasks.md` done).
 2. Verification has passed (via `/verify-code`).
-3. Changes are committed to a feature branch.
+3. Changes are committed AND pushed via `/commit-push` — this skill reads `git log origin/main..HEAD` but does not push.
 
 ---
 
@@ -45,11 +45,11 @@ Inspect the invocation arguments for a `--major` token (alongside the issue numb
 ESCALATION: --major flag requires human confirmation — unattended mode cannot apply a major version bump
 ```
 
-Do NOT continue to Step 1, do NOT read/write `VERSION`, `CHANGELOG.md`, or any stack-specific version file, do NOT commit or push, and do NOT create a PR.
+Do NOT continue to Step 1, do NOT commit or push, and do NOT create a PR. Version-bump mutation lives in `/commit-push`; this skill does not touch `VERSION` or `CHANGELOG.md`, but the escalation still fires here because the `--major` decision is a release-level call that belongs with PR opening.
 
 ### Step 1: Read Context
 
-Read `references/preflight.md` when Step 1 begins — the gate aborts before any version-artifact read/write if the working tree is dirty or the branch has no non-bump commits.
+Read `references/preflight.md` when Step 1 begins — the gate aborts before PR creation if the working tree is dirty, the branch has no non-bump commits, or local is not an ancestor of `origin/main` (i.e., `/commit-push` has not yet reconciled divergence).
 
 Gather all information needed for the PR:
 
@@ -61,27 +61,41 @@ Gather all information needed for the PR:
 
    Skip this sub-step if specs-not-found — acceptance criteria will be extracted from the issue body already fetched in step 1.
 4. **Read git state**:
-   - `git status` — any uncommitted changes?
+   - `git status` — any uncommitted changes (must be empty; /commit-push should have committed everything)?
    - `git log main..HEAD --oneline` — commits on this branch.
    - `git diff main...HEAD --stat` — files changed vs main.
-
-### Step 2: Determine Version Bump
-
-Read `references/version-bump.md` when a `VERSION` file exists at the project root **AND the issue does not carry the `spike` label** — the reference covers the current-version read, label-matrix lookup in `steering/tech.md`, the `--major` override, and the epic-child sibling-aware downgrade (including the epic-closure warning that gates on interactive vs. unattended mode). If no `VERSION` file exists, skip Steps 2 and 3 entirely. Spike-labelled issues skip Steps 2 and 3 entirely regardless of whether `VERSION` exists — the spike-skip branch is documented in `references/version-bump.md` § Spike handling and records `spike = true` for Step 4's PR body template.
-
-### Step 3: Update Version Artifacts
-
-Read `references/version-bump.md` when Step 2 produced a bump — the same reference covers writing the new version into `VERSION`, rolling the `[Unreleased]` CHANGELOG section under the new version heading (with partial-delivery annotation for intermediate epic children), updating stack-specific files from the `## Versioning` table, and committing with `chore: bump version to {new_version}`. Spike-labelled issues skip this step (no artifacts to update).
+5. **Read version artifacts for the PR body** — read `VERSION` and the latest heading in `CHANGELOG.md` to populate the PR body's Version line. Do NOT modify these files; `/commit-push` is the only skill that writes version artifacts.
 
 ### Step 4: Generate PR Content
 
-Read `references/pr-body.md` when assembling the PR title and body — the reference covers the conventional-commit title format, the specs-found Template A (full spec-linked body), and the specs-not-found Template B (fallback to issue-body ACs). Both templates include the conditional Version and epic-child "Bump" lines.
+Read `references/pr-body.md` when assembling the PR title and body — the reference covers the conventional-commit title format, the specs-found Template A (full spec-linked body), and the specs-not-found Template B (fallback to issue-body ACs). Both templates include the conditional Version and epic-child "Bump" lines. The Version line is populated from the committed `VERSION` file (and the latest CHANGELOG heading); this skill does not compute or write the bump itself.
 
-**Spike PRs**: when the session's `spike` flag is `true` (set by Step 2's spike-skip branch), the PR body template omits the `Version` line entirely and adds `Type: Spike research (no version bump)` in its place. The rest of the template (summary, specs reference, test plan) is unchanged.
+**Spike PRs**: the PR body template omits the `Version` line entirely and adds `Type: Spike research (no version bump)` in its place when the issue carries the `spike` label. The rest of the template (summary, specs reference, test plan) is unchanged.
 
-### Step 5: Push and Create PR
+### Step 5: Ancestry Check and Create PR
 
-Read `references/pr-body.md` when pushing and creating the PR — the reference covers the pre-push race-detection and re-bump logic for epic children (`git fetch`, ancestry check, rebase-and-amend, conflict handling that never force-pushes), the `git push -u origin HEAD` vs. `git push` branching, the `gh pr create` call, and the specs-found/specs-not-found output block.
+Verify local contains every commit in `origin/main`:
+
+```bash
+git merge-base --is-ancestor origin/main HEAD
+```
+
+- **Exit code 0**: local is up-to-date with or ahead of `origin/main` — proceed to `gh pr create`.
+- **Non-zero**: local is behind `origin/main` (divergence has not been reconciled). Exit non-zero with this exact line on stdout:
+
+  ```
+  DIVERGED: re-run commit-push to reconcile before creating PR
+  ```
+
+  Do NOT rebase, do NOT amend, do NOT push, do NOT force-push. The SDLC runner reads the `DIVERGED:` sentinel via `bounceContext` and bounces control to `/commit-push`, which owns rebase and push. In interactive use, the user re-runs `/commit-push` manually.
+
+Once the ancestry check passes, create the PR:
+
+```bash
+gh pr create --title "[title]" --body "[body]"
+```
+
+Add labels matching the issue when appropriate. Read `references/pr-body.md` for the output block.
 
 ### Step 6: Output (Base Case)
 
@@ -99,6 +113,6 @@ Read `references/ci-monitoring.md` when `.claude/unattended-mode` does NOT exist
 ## Integration with SDLC Workflow
 
 ```
-/draft-issue  →  /start-issue #N  →  /write-spec #N  →  /write-code #N  →  /simplify  →  /verify-code #N  →  /open-pr #N  →  /address-pr-comments #N
-                                                                                                                            ▲ You are here
+/draft-issue  →  /start-issue #N  →  /write-spec #N  →  /write-code #N  →  /simplify  →  /verify-code #N  →  /commit-push  →  /open-pr #N  →  /address-pr-comments #N
+                                                                                                                              ▲ You are here
 ```

--- a/skills/open-pr/references/pr-body.md
+++ b/skills/open-pr/references/pr-body.md
@@ -1,8 +1,8 @@
-# PR Body Templates and Push Logic
+# PR Body Templates
 
-**Consumed by**: `open-pr` Steps 4 (generate PR content) and 5 (push and create PR).
+**Consumed by**: `open-pr` Steps 4 (generate PR content) and 5 (create PR).
 
-Step 4 picks the PR body template based on the specs-found / specs-not-found flag from Step 1. Step 5 handles race detection with `origin/main` (for epic-child version bumps), the push itself, and the `gh pr create` invocation.
+Step 4 picks the PR body template based on the specs-found / specs-not-found flag from Step 1. Step 5 verifies local ancestry vs. `origin/main` and invokes `gh pr create`. Push and rebase responsibilities have moved to `/commit-push` — this reference no longer covers them.
 
 ## Step 4: Generate PR content
 
@@ -82,48 +82,25 @@ From issue body:
 Closes #N
 ```
 
-## Step 5: Push and create PR
+## Step 5: Create PR
 
-### 0. Pre-push race detection (epic children)
+Ancestry, push, and rebase are owned by `/commit-push` (see `skills/commit-push/references/rebase-and-push.md` for the force-with-lease envelope). By the time this reference is consulted, local must already be pushed and `origin/main` must already be an ancestor of HEAD.
 
-If Step 2/3 committed a version bump, detect whether `origin/{base-branch}` advanced during the local bump-and-commit (a concurrent epic-child PR merged first). Base branch is `main` unless a different target was specified.
+SKILL.md Step 5 runs a final ancestry check:
 
-1. Run `git fetch origin`.
-2. Run `git merge-base --is-ancestor HEAD origin/{base-branch}`. Exit code 0 → bases are in sync, skip to step 1 below.
-3. Non-zero (local is behind) → rebase:
-   ```bash
-   git pull --rebase origin {base-branch}
-   ```
-4. **Re-compute the bump** against the now-current `plugin.json` / `package.json` / `VERSION`:
-   - Re-read the current version from `VERSION` (authoritative per `steering/tech.md`).
-   - Apply the same `siblingClass`-aware bump logic from Step 2 to the new baseline.
-   - If the re-computed version differs from what was committed in Step 3, amend the version-bump commit:
-     ```bash
-     git checkout VERSION CHANGELOG.md [stack-specific files]
-     # redo Step 3 updates against the new baseline
-     git add VERSION CHANGELOG.md [stack-specific files]
-     git commit --amend -m "chore: bump version to {re-computed-new-version}" --no-edit
-     ```
-5. **Conflict handling.** If the rebase produces conflicts in `VERSION`, `plugin.json`, `marketplace.json`, `package.json`, or `CHANGELOG.md`, abort with:
-   ```
-   ERROR: rebase conflict in version file(s): {file-list}. Resolve manually and re-run /open-pr. Force-push is NEVER used by this skill.
-   ```
-   Exit non-zero. Do NOT pass `--force` or `--force-with-lease` to any `git push` invocation.
+```bash
+git merge-base --is-ancestor origin/main HEAD
+```
 
-### 1. Push
+Exit 0 → proceed to `gh pr create`. Non-zero → exit non-zero with the sentinel line `DIVERGED: re-run commit-push to reconcile before creating PR` on stdout. The SDLC runner reads this sentinel through `bounceContext` and bounces control back to `/commit-push`; in interactive use, the user re-runs `/commit-push` manually.
 
-Check if the remote tracking branch exists:
-
-- No remote tracking branch: `git push -u origin HEAD`.
-- Tracking branch exists but behind: `git push` (never `--force`).
-
-### 2. Create the PR
+### Create the PR
 
 ```bash
 gh pr create --title "[title]" --body "[body]"
 ```
 
-### 3. Labels
+### Labels
 
 Add labels matching the issue when appropriate.
 
@@ -143,4 +120,4 @@ Issue: Closes #N
 Then branch on the `.claude/unattended-mode` sentinel:
 
 - **Sentinel exists**: print `Done. Awaiting orchestrator.` and stop. Do NOT proceed to Step 7 — the runner owns CI monitoring and merging.
-- **Sentinel absent**: fall through to Step 7 (see `references/ci-monitoring.md`).
+- **Sentinel absent**: fall through to Step 7 (see `ci-monitoring.md`).

--- a/skills/open-pr/references/preflight.md
+++ b/skills/open-pr/references/preflight.md
@@ -2,7 +2,7 @@
 
 **Consumed by**: `open-pr` Step 1.
 
-Before reading or modifying `VERSION`, `CHANGELOG.md`, or any stack-specific version file, Step 1 must run both checks below in order. Either failure aborts the skill immediately — no version artifacts are touched.
+Before reading the issue, spec files, or `VERSION` / `CHANGELOG.md`, Step 1 must run the three checks below in order. Any failure aborts the skill immediately — no PR is created. `/open-pr` no longer owns version-artifact writes (that moved to `/commit-push`), so "no version artifacts are touched" is automatic; the checks below still exist because they guard PR creation against avoidable corruption of the pipeline handoff.
 
 ---
 
@@ -33,6 +33,28 @@ The exact abort string for this condition is:
 ```
 No implementation commits found on this branch — run /write-code before opening a PR.
 ```
+
+## Step 1c: Ancestry Check
+
+Verify `/commit-push` has already reconciled local with `origin/main` before PR creation:
+
+```bash
+git fetch origin main
+git merge-base --is-ancestor origin/main HEAD
+```
+
+- **Exit 0**: local contains every commit in `origin/main` — proceed to Step 1's existing reads (issue, spec files, git diff).
+- **Non-zero**: local is behind `origin/main` — abort. `/commit-push` owns the rebase; `/open-pr` must not rewrite history.
+
+### Divergence abort
+
+Print the exact sentinel line on stdout and exit non-zero (both interactive and unattended — the SDLC runner reads the sentinel via `bounceContext`):
+
+```
+DIVERGED: re-run commit-push to reconcile before creating PR
+```
+
+Do NOT rebase, do NOT amend, do NOT `git push`, and do NOT pass `--force` or `--force-with-lease` to any push. The sentinel is parsed by the runner to bounce control back to `/commit-push` (step 7 in the pipeline), which owns the rebase-and-push envelope.
 
 ---
 
@@ -77,4 +99,4 @@ ESCALATION: open-pr — No implementation commits found on this branch — run /
 
 ---
 
-In both failure cases: do NOT read or write `VERSION`, `CHANGELOG.md`, or any stack-specific version file, do NOT invoke `git add`, `git commit`, `git push`, or `gh pr create`.
+In all failure cases: do NOT invoke `git add`, `git commit`, `git push`, or `gh pr create`. `/open-pr` never writes to `VERSION`, `CHANGELOG.md`, or any stack-specific version file — those writes belong to `/commit-push`.

--- a/skills/start-issue/SKILL.md
+++ b/skills/start-issue/SKILL.md
@@ -32,6 +32,7 @@ The shared reference covers sentinel semantics; these skill-specific branches ap
     ├─ 1a. Dependency resolution (filter blocked, topological sort)
     ├─ 2.  Present issue selection (AskUserQuestion)
     ├─ 3.  Confirm selected issue
+    ├─ 3.5 Reconcile stale remote branch (if any)
     └─ 4.  Create linked feature branch & set issue to In Progress
          ├─ Precondition: working tree must be clean
          └─ Create branch, update status
@@ -150,6 +151,10 @@ If the user selects "Enter issue number manually", they type their issue number 
 Read the full issue details via `gh issue view #N` and present a brief summary: title and number, user story (if present), number of acceptance criteria, labels, and milestone.
 
 Ask: "Ready to start working on this issue?" If the user says no, return to Step 2.
+
+## Step 3.5: Reconcile Stale Remote Branch
+
+Read `references/stale-remote-branch.md` when the selected issue number is known and before `gh issue develop --checkout` runs — the reference covers branch-name derivation, remote existence probe, ancestor-of-main check, and the deletion path (auto-delete under unattended mode, interactive confirm otherwise). The probe is skipped when no remote branch exists.
 
 ## Step 4: Create Feature Branch & Link to Issue
 

--- a/skills/start-issue/references/stale-remote-branch.md
+++ b/skills/start-issue/references/stale-remote-branch.md
@@ -1,0 +1,95 @@
+# Stale Remote Branch Reconciliation
+
+**Consumed by**: `start-issue` Step 3.5 (before `gh issue develop --checkout` in Step 4).
+
+When the runner re-picks an issue that already has a remote feature branch from an earlier cycle, the remote tip reflects work against a now-outdated `main`. Step 4's `gh issue develop --checkout` checks out that stale tip, and any subsequent rebase-plus-push in `/commit-push` or `/open-pr` collides with the remote. This step detects that state and deletes the stale remote branch before a fresh cycle rebuilds local.
+
+The probe runs in **both** interactive and unattended modes — the difference is only whether deletion requires confirmation.
+
+---
+
+## Step 3.5 procedure
+
+### 1. Derive the feature branch name for issue #N
+
+Try the sources in order; stop at the first one that produces a branch name.
+
+1. **GitHub linked branches** — `gh issue view N --json linkedBranches --jq '.linkedBranches[0].name // empty'`. This is the authoritative source when the issue already has a branch linked via `gh issue develop`.
+2. **Fallback to the `{N}-{slug}` convention** — see `feature-naming.md` for the slug rules. Compute the expected name from the issue title.
+
+If both sources return empty, there is no stale branch to reconcile — skip to Step 4 silently (no log line needed; the probe found nothing to do).
+
+### 2. Probe for the remote branch
+
+```bash
+git ls-remote --heads origin {branch}
+```
+
+- **Empty output**: no remote branch exists — green path, proceed to Step 4 silently.
+- **Non-empty output**: a remote branch exists. Capture the remote tip SHA from the `ls-remote` output.
+
+### 3. Reachability check
+
+Fetch `main` so the ancestor check uses fresh data:
+
+```bash
+git fetch origin main
+```
+
+Then check whether the remote tip is reachable from `origin/main`:
+
+```bash
+git merge-base --is-ancestor {remote-tip-sha} origin/main
+```
+
+- **Exit 0**: the remote tip is already merged into `main` (or is `main`'s current tip) — the branch is not stale, skip to Step 4 silently.
+- **Non-zero**: the remote tip is NOT reachable from `origin/main` — the branch is **stale**. Proceed to Step 4 of this procedure.
+
+### 4. Delete the stale remote branch
+
+Unattended-mode deterministic-default (per `../../../references/unattended-mode.md`): delete without prompting. Interactive mode: confirm first.
+
+#### Unattended mode (`.claude/unattended-mode` exists)
+
+```bash
+git push origin --delete {branch}
+```
+
+Log exactly:
+
+```
+Reconciled stale remote branch {branch} (tip {short-sha} not ancestor of origin/main)
+```
+
+Proceed to Step 4 — `gh issue develop --checkout` will now create a fresh branch against current `origin/main`.
+
+#### Interactive mode
+
+Use `AskUserQuestion` with two options:
+
+- `[1] Delete stale branch and proceed` — issue `git push origin --delete {branch}`, log the "Reconciled stale remote branch" line, and proceed to Step 4.
+- `[2] Abort — keep stale branch for inspection` — exit non-zero without creating a branch so the user can inspect the remote state before re-running.
+
+### 5. Logging rules
+
+- The probe emits no log line when there is no remote branch (green path).
+- The probe emits no log line when the remote branch is reachable from `origin/main` (already merged, not stale).
+- The probe emits exactly one log line on a successful deletion: `Reconciled stale remote branch {branch} (tip {short-sha} not ancestor of origin/main)`.
+- An interactive abort (option `[2]`) emits no log line — the user chose to inspect.
+
+The `--is-ancestor` check is authoritative. Do not fall back to timestamp comparisons or commit-count heuristics — either the remote tip is in `origin/main`'s history or it is not.
+
+---
+
+## Why `origin/main` (not `main`)
+
+The probe runs before Step 4, and Step 4's branch creation uses `gh issue develop --checkout` which writes a new local branch but does not update local `main`. Using `origin/main` (after the `git fetch origin main`) ensures the ancestor check compares against the freshest remote state, not whatever stale local `main` the working tree happens to hold.
+
+## Edge cases
+
+| Case | Behaviour |
+|------|-----------|
+| Remote branch exists but `git ls-remote` returns it with a tag-like suffix | Match strictly on the full ref name; ignore tags |
+| Multiple remote branches match (e.g. `249-foo` and `249-foo-v2`) | Take the branch whose name the `gh issue view` linked-branches query reports; ignore others |
+| `git fetch origin main` fails (network/auth) | Skip the probe entirely; emit `WARNING: stale-remote probe skipped (fetch failed)` and proceed to Step 4. Do not abort — the runner's dirty-tree check still fires before branch creation. |
+| The remote branch exists AND is reachable from `origin/main` | Skip silently — the branch has been merged and the remote hasn't been cleaned up yet; it is not stale for our purposes |

--- a/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/design.md
+++ b/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/design.md
@@ -1,0 +1,125 @@
+# Root Cause Analysis: Unattended SDLC Runner Cascade Failure on Diverged Remote Branch
+
+**Issue**: #102
+**Date**: 2026-04-23
+**Status**: Draft
+**Author**: Rich Nunley
+
+---
+
+## Root Cause
+
+The cascade has six interlocking defects across two surfaces — the SDLC runner (`scripts/sdlc-runner.mjs`) and the `/open-pr` skill instructions (`skills/open-pr/`). Each defect by itself is survivable; together they form a trap that only springs when (a) the remote feature branch has diverged from local and (b) the runner is in unattended mode.
+
+**(A) `createPR` owns history reconciliation.** The `/open-pr` skill's Step 5 Section 0 ("Pre-push race detection") instructs the subagent to detect advanced `origin/main`, run `git pull --rebase origin main`, re-compute and `--amend` the version-bump commit, then `git push` without `--force`. The ref `references/pr-body.md:107-111` explicitly forbids `--force-with-lease`. When the rebase succeeds, the push is non-fast-forward because the remote still holds pre-rebase SHAs — rejected.
+
+**(B) `commitPush` refuses force-push in unattended mode.** The runner-generated prompt at `scripts/sdlc-runner.mjs:979` tells the subagent to "push to the remote branch". Without explicit permission to force-push, the haiku subagent defaults to the conservative path: "I won't force-push without your confirmation." In unattended mode there is no confirmer, so all three retry attempts end the same way.
+
+**(C) Runner misclassifies `error_max_turns` as rate-limit.** `matchErrorPattern` at `scripts/sdlc-runner.mjs:1132-1140` tests only `/rate_limit/i` and `IMMEDIATE_ESCALATION_PATTERNS`. When a step session exits with `subtype: "error_max_turns"`, nothing in `matchErrorPattern` catches it — but `handleFailure` at `scripts/sdlc-runner.mjs:1299-1303` still matches the output against the rate-limit regex and produces `"Rate limited. Waiting 60s before retry..."`. The actual `error_max_turns` path only fires inside `detectSoftFailure` (line 1186), which runs in the happy-path branch (exit code 0). On a non-zero exit it never runs.
+
+**(D) `createPR` has too many responsibilities for its budget.** Per `skills/open-pr/SKILL.md`, the skill does: preflight + version-bump + changelog roll + commit + pre-push race detection + rebase + amend + push + `gh pr create` + label add + optional CI monitor. Issue #249's config used `maxTurns: 15` (the current default is 45 in `scripts/sdlc-config.example.json`, but that's still a lot of responsibilities for a "create PR" step).
+
+**(E) Step bouncing loses state.** When `runStep` bounces to the previous step (`scripts/sdlc-runner.mjs:2073-2077` and `1305-1318`), the only things passed forward are `currentStep` and the retry counter in `sdlc-state.json`. The receiving step's prompt is regenerated from `buildClaudeArgs` with no knowledge of *why* it was re-invoked — so the `commitPush` subagent spends turns re-investigating divergence from scratch on every bounce.
+
+**(F) `startIssue` does not reconcile stale remote branches.** When the runner re-picks an issue whose feature branch was pushed in an earlier cycle, `skills/start-issue/SKILL.md` Step 4 calls `gh issue develop N --checkout`, which checks out the existing remote branch. The remote tip reflects the earlier cycle's work; local will be rebuilt fresh as the new cycle proceeds. Any subsequent rebase-then-push in `createPR` collides with the stale remote.
+
+### Affected Code
+
+| File | Lines | Role |
+|------|-------|------|
+| `scripts/sdlc-runner.mjs` | 1132, 1134-1140 | `RATE_LIMIT_PATTERN` + `matchErrorPattern` — no `error_max_turns` branch |
+| `scripts/sdlc-runner.mjs` | 1292-1303 | `handleFailure` — rate-limit wait path runs before `error_max_turns` is detected |
+| `scripts/sdlc-runner.mjs` | 1183-1214 | `detectSoftFailure` — already detects `error_max_turns` but only on exit-code-0 path |
+| `scripts/sdlc-runner.mjs` | 2048-2080, 1305-1318 | `runStep` / `handleFailure` bounce path — no structured context passed to N-1 |
+| `scripts/sdlc-runner.mjs` | 938-1001 | `buildClaudeArgs` prompt table — no hook for bounce context injection |
+| `scripts/sdlc-runner.mjs` | 979 | `commitPush` inline prompt — tells subagent to `git push` without force-with-lease guidance |
+| `scripts/sdlc-runner.mjs` | 981 | `createPR` inline prompt — hardcodes the version-bump responsibility |
+| `skills/open-pr/SKILL.md` | Steps 2, 3, 5 | Version-bump + pre-push race detection + rebase-and-amend |
+| `skills/open-pr/references/pr-body.md` | 87-118 | Section 0 pre-push race detection + Section 1 push rules forbidding `--force-with-lease` |
+| `skills/start-issue/SKILL.md` | Step 4 (via `references/dirty-tree.md`) | No stale-remote-branch probe before branch creation |
+
+### Triggering Conditions
+
+- The runner is in unattended mode (`.claude/unattended-mode` sentinel present).
+- The feature branch has diverged from local: either a stale remote tip from an earlier cycle (`startIssue` contributing) or `main` advanced mid-run (epic-child scenario).
+- `createPR` reaches its pre-push race-detection branch, rebases, and attempts the non-force push.
+
+Why these conditions weren't caught before: the rebase-and-push logic in `/open-pr` was designed for the epic-child race case (sibling merged mid-run) where `--force-with-lease` is unnecessary because local was never ahead of remote. It was never exercised against a stale remote branch whose tip is behind local post-rebase.
+
+---
+
+## Fix Strategy
+
+### Approach
+
+Split the fix along the six defects. Each defect gets a surgical change, and the six together restore the unattended `createPR → commitPush` handoff. No new skills are introduced; existing skills are re-scoped and the runner gains an `error_max_turns` branch plus a bounce-context channel.
+
+- **(A, D)** Trim `/open-pr` to preconditions + PR body assembly + `gh pr create` + post-create labelling. Move version-bump (current Steps 2–3), changelog roll, and pre-push race detection + rebase out. This makes `/open-pr` fit its name and frees it from the turn-budget pressure that caused Bug D.
+- **(B)** Relocate the commit-push-and-bump-version work to a new `skills/commit-push/` skill with an explicit unattended-mode branch that allows `git push --force-with-lease` when the lease check is safe. The runner's `commitPush` step gets the `skill: 'commit-push'` pointer (matching `startIssue`, `writeSpecs`, `implement`, `verify`, `createPR` — the other skill-backed steps).
+- **(C)** Extend `matchErrorPattern` (or thread through `handleFailure`) to recognize `subtype: "error_max_turns"` in the parsed result stream **before** the rate-limit regex runs. On match, skip the rate-limit wait entirely and return an `error_max_turns`-specific action.
+- **(E)** Add a module-level `bounceContext` object set when `retry-previous` fires. `buildClaudeArgs` prepends a structured "Bounce context" block to the next step's prompt when the context is non-null, then `runStep` clears it after the step runs.
+- **(F)** Add a Step 3.5 to `/start-issue` (before branch creation in Step 4) that probes for an existing remote feature branch matching the selected issue number; when its tip is not reachable from `origin/main`, delete the stale remote branch with `git push origin --delete {branch}` so `gh issue develop --checkout` creates a fresh one.
+- **(FR6)** Keep `createPR` `maxTurns` at 45 through this fix; add a tasks.md verify step that confirms post-FR1 runs complete within a smaller envelope, and lower the default to 20 only if three consecutive unattended runs stay under that threshold.
+
+### Changes
+
+| File | Change | Rationale |
+|------|--------|-----------|
+| `skills/commit-push/SKILL.md` | **Create.** Own: stage changes, version-bump + changelog roll (moved from `/open-pr`), commit, fetch + ancestry check against `origin/main`, rebase on divergence, push. In unattended mode + post-rebase + safe lease → `git push --force-with-lease`. | Gives FR1's displaced work a proper home and scopes the force-with-lease exception to exactly the conditions where it is safe (AC2). |
+| `skills/commit-push/references/rebase-and-push.md` | **Create.** Relocate Section 0 (pre-push race detection + rebase + amend) from `skills/open-pr/references/pr-body.md` verbatim, plus a new "force-with-lease under unattended + diverged" subsection. | Keeps the detailed procedure close to its skill; avoids bloating SKILL.md. |
+| `skills/commit-push/references/version-bump-delegation.md` | **Create.** Pointer doc that references `skills/open-pr/references/version-bump.md` for the bump matrix and artifact-update procedure. | The version-bump logic itself is unchanged (FR1 moves the call site, not the mechanism — see Out of Scope). A pointer avoids duplication. |
+| `skills/open-pr/SKILL.md` | **Modify.** Remove Steps 2, 3, and Step 5 Section 0 (race detection + rebase). Step 5 becomes: "verify ancestry of `HEAD` with `origin/main`; if diverged, exit non-zero with `DIVERGED: re-run commit-push to reconcile` so the runner bounces to step 7; otherwise `gh pr create`." | AC4: createPR scoped to preconditions + `gh pr create`. |
+| `skills/open-pr/references/pr-body.md` | **Modify.** Delete Section 0 (pre-push race detection) and the `git push` rules in Section 1; the skill no longer pushes. Keep Template A / Template B body content and the output block. | No push duty remains in `/open-pr`, so the push rules shouldn't live here. |
+| `skills/start-issue/SKILL.md` | **Modify.** Insert Step 3.5 "Reconcile stale remote branch" before Step 4. Add a pointer to the new reference. | AC7: stale remote deleted before `gh issue develop` re-attaches. |
+| `skills/start-issue/references/stale-remote-branch.md` | **Create.** Procedure: resolve the branch name for the selected issue (`gh issue view N --json linkedBranches` + fallback to `gh issue develop --list`), probe with `git ls-remote`, reachability check `git merge-base --is-ancestor <remote-tip> origin/main`, delete via `git push origin --delete` when stale, log each action. | Keeps the procedure close to `/start-issue` and follows the plugin's convention of pointing into references for multi-step procedures. |
+| `scripts/sdlc-runner.mjs` — `matchErrorPattern` / `handleFailure` | **Modify.** Before the rate-limit regex runs, call `extractResultFromStream(output)` and check `parsed?.subtype === 'error_max_turns'`. On match, return `{ action: 'max_turns', pattern: 'error_max_turns' }`. `handleFailure` adds a branch for that action: log `"Turn budget exhausted on Step N (key). Bouncing to Step N-1..."`, do **not** sleep, and fall through to the existing precondition-failed bounce path (which re-routes control to the prior step). | AC3: removes the false rate-limit classification. Reuses the existing bounce path rather than inventing a new recovery action, keeping blast radius small. |
+| `scripts/sdlc-runner.mjs` — bounce context | **Modify.** Add `let bounceContext = null` at module scope near `bounceCount`. Set it in both bounce sites (`runStep` lines 2073-2077 and `handleFailure` lines 1305-1318) to `{ from: step.key, fromStepNumber: step.number, reason: 'precondition_failed' \| 'error_max_turns', failedCheck, divergenceHints: {} }`. In `buildClaudeArgs`, when `bounceContext` is non-null and `bounceContext.fromStepNumber === step.number + 1` (receiving the bounce), prepend a "## Bounce context" block to the prompt. Clear `bounceContext = null` at the end of `runStep` after a successful run. | AC5: structured context survives the prompt boundary. |
+| `scripts/sdlc-runner.mjs` — `commitPush` prompt | **Modify.** Replace the inline prompt at line 979 with a `skill: 'commit-push'`-backed pointer, matching the pattern used for `startIssue`, `writeSpecs`, etc. | Moves the push-and-bump instructions out of the runner's prompt table and into the skill where they belong. |
+| `scripts/sdlc-config.example.json` | **Modify.** Add `"skill": "commit-push"` to the `commitPush` step entry. `createPR` keeps `maxTurns: 45` through this fix (FR6 re-evaluation happens after). | Runner looks up `step.skill` when building the prompt; the new skill needs to be wired. |
+| `scripts/__tests__/` | **Modify.** Add tests for: `matchErrorPattern` returning `max_turns` on an `error_max_turns` result; bounce-context injection into `buildClaudeArgs`; stale-branch probe logic (if extracted as a testable helper). | Regression guard for FR3, FR4, and FR5. |
+
+### Blast Radius
+
+- **Direct impact:** `scripts/sdlc-runner.mjs`, `scripts/sdlc-config.example.json`, `skills/open-pr/SKILL.md`, `skills/open-pr/references/pr-body.md`, `skills/start-issue/SKILL.md`, new `skills/commit-push/` tree, new `skills/start-issue/references/stale-remote-branch.md`.
+- **Indirect impact:**
+  - `skills/open-pr/references/version-bump.md`, `skills/open-pr/references/preflight.md`, `skills/open-pr/references/ci-monitoring.md` — read unchanged by the trimmed `/open-pr`; `commit-push` references `version-bump.md` rather than duplicating it.
+  - `scripts/skill-inventory-audit.mjs` / `scripts/skill-inventory.baseline.json` — the new skill must be added to the baseline or the audit workflow will flag it as undeclared.
+  - Downstream skills (`address-pr-comments`, `verify-code`) that assume the push has happened before PR creation still see the same postcondition; the pipeline contract is preserved.
+- **Risk level:** Medium. The change moves responsibilities across skills; the move is mechanical but touches the fast-running `commitPush` step and the most-exercised `/open-pr` skill.
+
+---
+
+## Regression Risk
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Green-path unattended cycle starts using force-with-lease unnecessarily | Low | AC2 explicitly gates force-with-lease on (unattended + local was rebased). Test in `scripts/__tests__/` for the push-decision helper covers the no-divergence case. |
+| Interactive (non-unattended) force-push behavior changes | Low | The commit-push skill's force-with-lease branch is guarded by the `.claude/unattended-mode` sentinel check; interactive runs fall through to plain `git push`. Out of Scope AC2 still holds. |
+| Bounce context leaks across unrelated steps / issues | Medium | Clear `bounceContext = null` at the top of `runStep` and at the start of a new cycle. Test coverage for the clear path. |
+| `error_max_turns` detection false-positives on unrelated JSON with the phrase | Low | Match via `extractResultFromStream` (parsed JSON) not raw regex. `detectSoftFailure` already uses the same path successfully. |
+| Stale-branch delete removes a branch the user wanted to inspect | Medium | The probe fires only for the selected issue number and only when the remote tip is not an ancestor of `origin/main`. Log the delete. Consider a `--keep-stale-branches` runner flag if operator feedback warrants. |
+| `/open-pr` precondition check ("ancestry vs origin/main") fails on an already-diverged branch and loops | Medium | The new ancestry check exits with a distinct `DIVERGED:` marker that bounce-context propagates to `commit-push`; `commit-push` reconciles and returns control. The bounce-loop counter (`MAX_BOUNCE_RETRIES`) still guards the overall loop. |
+| `skill-inventory-audit` fails on the new `commit-push` skill until the baseline is updated | Low | Update `skill-inventory.baseline.json` in the same PR. |
+
+---
+
+## Alternatives Considered
+
+| Option | Description | Why Not Selected |
+|--------|-------------|------------------|
+| Teach `/open-pr` to force-push with lease | Keep the rebase-in-createPR topology; just allow `--force-with-lease` after the rebase when unattended. | Leaves createPR overloaded (Bug D) and does not address FR1's scope-creep goal. Would also widen the blast radius of `/open-pr` instead of narrowing it. |
+| Create a dedicated `rebase` step between `verify` and `commitPush` | Adds a new pipeline step for history reconciliation. | Topology change — AC4 and Out of Scope explicitly narrow the fix to existing steps. Also forces every green-path run through a no-op step. |
+| Handle divergence entirely in the runner (no skill changes) | `runStep` detects `git push` failure, re-spawns `commit-push` with force-with-lease. | Force-push policy is a skill-authoring concern, not a runner concern. Would duplicate `git` knowledge in two places. |
+| Keep `matchErrorPattern` regex-only; widen the regex to `/rate_limit\|error_max_turns/` | Minimal change to the runner. | Produces the wrong action — rate-limit sleeps 60s, `error_max_turns` should bounce. Regex match loses semantic distinction. |
+
+---
+
+## Validation Checklist
+
+Before moving to TASKS phase:
+
+- [x] Root cause is identified with specific code references
+- [x] Fix is minimal relative to the six-defect scope — no unrelated refactoring
+- [x] Blast radius is assessed
+- [x] Regression risks are documented with mitigations
+- [x] Fix follows existing project patterns (skill-backed steps, reference-file progressive disclosure, sentinel-guarded unattended branches)

--- a/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/feature.gherkin
+++ b/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/feature.gherkin
@@ -1,0 +1,97 @@
+# File: specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/feature.gherkin
+#
+# Generated from: specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/requirements.md
+# Issue: #102
+# Type: Defect regression
+
+@regression
+Feature: Unattended SDLC runner handles diverged remote branches without cascade failure
+  The createPR step previously rewrote history then non-force-pushed, the runner mis-classified the
+  resulting error_max_turns as rate-limiting, and commitPush refused to force-push without a user it
+  could not reach under unattended mode. This was fixed by moving version-bump + rebase + push into
+  a new commit-push skill with force-with-lease support under unattended mode, teaching the runner
+  to distinguish error_max_turns from rate-limiting, threading structured bounce context between
+  steps, and reconciling stale remote branches in start-issue before re-picked cycles rebuild local.
+
+  # --- AC1: createPR does not non-force-push after rewriting history ---
+
+  @regression
+  Scenario: createPR delegates history reconciliation to commit-push
+    Given createPR runs on branch "249-fix-config-init-custom-path" whose remote has diverged from local
+    When the skill reaches its push step
+    Then the skill does not run "git reset --hard" or "git pull --rebase" itself
+    And the skill exits non-zero with "DIVERGED: re-run commit-push to reconcile before creating PR" when local is not an ancestor of origin/main
+    And no non-force "git push" is issued by createPR after a history rewrite
+
+  # --- AC2: commitPush force-pushes with lease in unattended mode when safe ---
+
+  @regression
+  Scenario: commit-push uses --force-with-lease under unattended mode after rebase
+    Given the runner is in unattended mode with ".claude/unattended-mode" present
+    And commit-push has rebased local onto origin/main so the remote tip is no longer in local history
+    And the remote tip matches the SHA captured in the fetch that preceded the rebase
+    When commit-push evaluates the push
+    Then it issues "git push --force-with-lease=ref:<expected-sha>" without prompting
+    And the push succeeds without operator input
+
+  # --- AC3: Runner distinguishes error_max_turns from rate-limiting ---
+
+  @regression
+  Scenario: matchErrorPattern catches error_max_turns before the rate-limit regex
+    Given a step session exits with a result stream containing "\"subtype\":\"error_max_turns\""
+    When handleFailure inspects the result
+    Then the runner log does NOT contain "Rate limited. Waiting 60s before retry..."
+    And the runner does NOT sleep for 60 seconds
+    And handleFailure takes the error_max_turns recovery branch with an accurate status message
+
+  # --- AC4: createPR is scoped to its name ---
+
+  @regression
+  Scenario: createPR has no version-bump or rebase responsibilities
+    Given /open-pr SKILL.md after the fix
+    When its workflow is read
+    Then the workflow contains precondition checks, ancestry check vs origin/main, and "gh pr create"
+    And the workflow does NOT contain steps for version bumping, changelog rolling, or history reconciliation
+    And "skills/open-pr/references/pr-body.md" does NOT contain Section 0 pre-push race detection or push rules
+
+  # --- AC5: Bounce transitions carry structured state ---
+
+  @regression
+  Scenario: Bounced step receives structured bounce context in its prompt
+    Given step 8 (createPR) fails its precondition check with failedCheck "branch pushed to remote"
+    And the runner bounces to step 7 (commitPush)
+    When buildClaudeArgs is called for step 7
+    Then the generated prompt begins with a "## Bounce context" block
+    And the block contains the keys "from:", "reason:", "failedCheck:", "remoteCommitsSuperseded:"
+    And the receiving commit-push subagent does not need to re-investigate the divergence from scratch
+
+  # --- AC6: createPR budget fits its responsibilities ---
+
+  @regression
+  Scenario: createPR completes within the re-evaluated turn budget
+    Given createPR has been scoped to preconditions + "gh pr create" + labels (post-FR1)
+    When createPR runs on three consecutive unattended green-path cycles
+    Then every run completes within the configured "maxTurns" without an error_max_turns result
+    And if the p95 turn usage is under 20, "sdlc-config.example.json" reflects the lowered default
+
+  # --- AC7: startIssue reconciles stale remote branches ---
+
+  @regression
+  Scenario: start-issue deletes a stale remote branch before rebuild
+    Given the runner picks issue #249
+    And origin/249-fix-config-init-custom-path exists with a tip that is not reachable from origin/main
+    When /start-issue Step 3.5 runs in unattended mode
+    Then the runner logs "Reconciled stale remote branch 249-fix-config-init-custom-path (tip <sha> not ancestor of origin/main)"
+    And "git push origin --delete 249-fix-config-init-custom-path" has been issued
+    And Step 4 "gh issue develop --checkout" creates a fresh feature branch against the current origin/main
+
+  # --- AC8: No regression for the green-path cycle ---
+
+  @regression
+  Scenario: Green-path unattended cycle does not invoke any new recovery paths
+    Given a fresh unattended cycle on an issue with no pre-existing remote branch
+    And origin/main does not advance during the run
+    When the runner executes all steps end-to-end
+    Then the PR is created normally and CI monitoring proceeds
+    And the runner log contains NONE of "force-with-lease", "Reconciled stale remote branch", or "## Bounce context"
+    And no step exits with "DIVERGED: re-run commit-push to reconcile before creating PR"

--- a/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/requirements.md
+++ b/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/requirements.md
@@ -1,0 +1,162 @@
+# Defect Report: Unattended SDLC Runner Cascade Failure on Diverged Remote Branch
+
+**Issue**: #102
+**Date**: 2026-04-23
+**Status**: Draft
+**Author**: Rich Nunley
+**Severity**: High
+**Related Spec**: `specs/feature-add-skill-to-run-full-sdlc-pipeline-loop-from-within-claude-code/`
+
+---
+
+## Reproduction
+
+### Steps to Reproduce
+
+1. Run the unattended SDLC runner on an issue whose remote branch was pushed in an earlier cycle against an older `main`.
+2. Let `main` advance (merge another PR) while the runner is working.
+3. Observe `commitPush` (Step 7) succeeds, then `createPR` (Step 8) detects advanced `main`, runs `git reset --hard HEAD~1` + `git pull --rebase origin main`, re-bumps the version, and issues a plain `git push`.
+4. The remote rejects the push non-fast-forward.
+5. `createPR` hits the per-step turn cap and exits with `subtype: error_max_turns`.
+6. The runner logs `"Rate limited. Waiting 60s before retry..."` and bounces to `commitPush`.
+7. `commitPush`'s subagent diagnoses divergence and refuses to force-push without user confirmation (which unattended mode cannot provide).
+8. The runner's push validator counts "unpushed commits remain" as failure and retries.
+9. Steps 7–8 repeat until the retry budget is exhausted; the runner escalates. No PR exists.
+
+### Environment
+
+| Factor | Value |
+|--------|-------|
+| **OS / Platform** | macOS (Darwin 25.3.0) |
+| **Version / Commit** | nmg-sdlc plugin 1.58.0; runner log timestamped 2026-04-22 02:51–02:58 |
+| **Runtime** | SDLC runner (`scripts/sdlc-runner.mjs`), Claude Code unattended mode |
+
+### Frequency
+
+Always — reproduces deterministically whenever the remote feature branch has diverged from local (either from a stale earlier-cycle push or a concurrent `main` advance during the run). Confirmed across three sequential `commitPush` attempts on issue #249 with identical "won't force-push without confirmation" output.
+
+---
+
+## Expected vs Actual
+
+| | Description |
+|---|-------------|
+| **Expected** | Under unattended mode, the `createPR → commitPush` handoff completes without human input when the remote has diverged. History reconciliation lives outside `createPR`; `commitPush` may `git push --force-with-lease` automatically when the lease check is safe; the runner distinguishes `error_max_turns` from rate-limiting; bounce transitions carry a structured reason so the receiving step does not re-investigate from scratch; `startIssue` reconciles stale remote branches before a re-picked cycle rebuilds local. |
+| **Actual** | `createPR` rewrites history and non-force-pushes; the resulting `error_max_turns` is misclassified as rate-limiting; `commitPush` refuses the force-push three times in a row; the runner exhausts its retry budget and escalates. The branch is left diverged, no PR exists, and operator-facing logs claim `"Rate limited"` when the real failure was `error_max_turns` plus force-push-confirmation-in-headless-mode. |
+
+### Error Output
+
+```
+[commitPush session excerpt — repeated identically across three retry attempts]
+A plain git push will be rejected … I won't force-push without your confirmation.
+
+[runner log excerpt]
+Rate limited. Waiting 60s before retry...
+[STATUS] Rate limited on Step 8. Waiting 60s...
+```
+
+---
+
+## Acceptance Criteria
+
+**IMPORTANT: Each criterion becomes a Gherkin BDD test scenario.**
+
+### AC1: createPR does not non-force-push after rewriting history
+
+**Given** `createPR` runs on a branch whose remote has diverged from local (stale remote commits or `main` advanced mid-run)
+**When** the step completes its push
+**Then** either the step does not rewrite history at all (delegating to `commitPush` or a dedicated rebase step), or its push uses `git push --force-with-lease` paired with the rewrite
+
+### AC2: commitPush force-pushes with lease in unattended mode when safe
+
+**Given** the runner is in unattended mode and local history has been rebased such that the remote tip is no longer in local history
+**And** the remote tip matches what was last fetched (the `--force-with-lease` safety check holds)
+**When** `commitPush`'s subagent evaluates the push
+**Then** it issues `git push --force-with-lease` without asking for user confirmation
+
+### AC3: Runner distinguishes error_max_turns from rate-limiting
+
+**Given** a step session exits with `subtype: "error_max_turns"`
+**When** `handleFailure` inspects the result
+**Then** the runner does NOT log `"Rate limited. Waiting 60s before retry..."` and does NOT sleep on the rate-limit path
+**And** takes an `error_max_turns`-specific recovery action with an accurate status message
+
+### AC4: createPR is scoped to its name
+
+**Given** `createPR` is invoked after `commitPush`
+**When** it runs
+**Then** its responsibilities are limited to preconditions check + `gh pr create` (plus post-create artifact linking such as labels)
+**And** version bumping, changelog updates, rebase, and history reconciliation live in `implement` / `commitPush` / a dedicated step — never inside `createPR`
+
+### AC5: Bounce transitions carry structured state
+
+**Given** step N fails its precondition check and bounces to step N-1
+**When** step N-1 runs
+**Then** its prompt includes a structured bounce reason (at minimum: `from`, `reason`, `detected_divergence`, `remote_commits_superseded`) so the receiving subagent does not re-investigate from scratch
+
+### AC6: createPR budget fits its responsibilities
+
+**Given** AC4 has scoped `createPR` to preconditions + PR creation
+**When** `createPR` executes
+**Then** its `maxTurns` budget is sufficient for that scope under normal conditions
+**And** the budget is re-evaluated post-FR1 and raised only if still insufficient
+
+### AC7: startIssue reconciles stale remote branches
+
+**Given** the runner picks an issue that already has a remote feature branch whose tip is not reachable from `main`
+**When** `startIssue` runs at the top of the cycle
+**Then** it detects the stale branch and either deletes it or hard-resets it to the fresh base **before** the runner rebuilds local
+**And** the action is logged
+
+### AC8: No regression for the green-path cycle
+
+**Given** a fresh unattended cycle on an issue with no pre-existing remote branch and no concurrent `main` advance
+**When** the runner executes all steps end-to-end
+**Then** the cycle completes without invoking any of the new force-push / stale-branch / bounce-reason paths, and the PR is created normally
+
+---
+
+## Functional Requirements
+
+| ID  | Requirement | Priority |
+|-----|-------------|----------|
+| FR1 | `createPR` skill no longer runs `git reset --hard` + rebase + non-force push; history reconciliation moves out of the skill (scope creep removed) | Must |
+| FR2 | `commitPush` skill instructions allow `git push --force-with-lease` without user confirmation when unattended-mode is active and the lease check is safe | Must |
+| FR3 | `sdlc-runner.mjs` `matchErrorPattern` / `handleFailure` branches on result `subtype === 'error_max_turns'` before the rate-limit path runs | Must |
+| FR4 | `sdlc-runner.mjs` passes a structured bounce-reason object (at minimum `from`, `reason`, and divergence hints) into the downstream step's prompt when `retry-previous` fires | Must |
+| FR5 | `startIssue` skill detects and reconciles stale remote feature branches before the runner begins a fresh implementation cycle | Must |
+| FR6 | `createPR` `maxTurns` budget is re-evaluated against the post-FR1 scope; raised only if still insufficient | Should |
+
+---
+
+## Out of Scope
+
+- Multi-repo coordination across sibling plugins
+- Changes to interactive (non-unattended) behavior of `commitPush` force-push prompts
+- Broader refactor of the runner's error-pattern matcher beyond `error_max_turns`
+- Version-bump mechanism redesign (FR1 moves the call site, not the mechanism)
+- Changes to the `createPR` skill's name/step-number in the runner pipeline (the fix adjusts scope, not topology)
+
+---
+
+## Evidence
+
+- Runner log: `/var/folders/.../T/sdlc-logs/agentchrome/sdlc-runner.log`
+- Failed `createPR` sessions: `createPR-e76ff163-*.log`, `createPR-1f3fce65-*.log`
+- Failed `commitPush` sessions: `commitPush-16370bb1-*.log`, `commitPush-d51e3473-*.log`, `commitPush-5f7eed43-*.log`
+
+All three failed `commitPush` sessions produced identical "won't force-push without confirmation" output — high-confidence reproducer for the AC2 fix.
+
+---
+
+## Validation Checklist
+
+Before moving to PLAN phase:
+
+- [x] Reproduction steps are repeatable and specific
+- [x] Expected vs actual behavior is clearly stated
+- [x] Severity is assessed
+- [x] Acceptance criteria use Given/When/Then format
+- [x] At least one regression scenario is included (AC8)
+- [x] Fix scope is minimal — no feature work mixed in
+- [x] Out of scope is defined

--- a/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/tasks.md
+++ b/specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: Unattended SDLC Runner Cascade Failure on Diverged Remote Branch
+
+**Issue**: #102
+**Date**: 2026-04-23
+**Status**: Planning
+**Author**: Rich Nunley
+
+---
+
+## Summary
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T001 | Add `error_max_turns` branch to `matchErrorPattern` / `handleFailure` (FR3) | [ ] |
+| T002 | Add `bounceContext` module state + inject into `buildClaudeArgs` (FR4) | [ ] |
+| T003 | Create `skills/commit-push/` with SKILL.md + references (FR1, FR2) | [ ] |
+| T004 | Trim `/open-pr` of version-bump + pre-push rebase (FR1 complement) | [ ] |
+| T005 | Add stale-remote-branch probe to `/start-issue` (FR5) | [ ] |
+| T006 | Wire runner prompt + config for `commit-push` skill; update skill-inventory baseline | [ ] |
+| T007 | Add regression tests (`error_max_turns`, bounce context, stale-branch probe) | [ ] |
+| T008 | Write `@regression` Gherkin scenarios for all 8 ACs | [ ] |
+| T009 | End-to-end verification + re-evaluate `createPR` maxTurns (FR6) | [ ] |
+
+---
+
+### T001: Add error_max_turns branch to matchErrorPattern / handleFailure
+
+**File(s)**: `scripts/sdlc-runner.mjs` (lines 1132-1140 `matchErrorPattern`; lines 1291-1303 `handleFailure`)
+**Type**: Modify
+**Depends**: None
+**Acceptance**:
+- [ ] `matchErrorPattern` calls `extractResultFromStream(output)` and, when `parsed?.subtype === 'error_max_turns'`, returns `{ action: 'max_turns', pattern: 'error_max_turns' }` **before** the `RATE_LIMIT_PATTERN` regex runs.
+- [ ] `handleFailure` branches on `patternMatch?.action === 'max_turns'`: logs `"Turn budget exhausted on Step N (key)."` (no `"Rate limited"` string in the output), does **not** sleep, and proceeds into the existing precondition-failed bounce path so control returns to the previous step.
+- [ ] A session that exits with `subtype: "error_max_turns"` produces no `"Rate limited. Waiting 60s before retry..."` in the runner log.
+- [ ] Existing rate-limit behavior (`/rate_limit/i`) is preserved for genuine rate-limit failures.
+
+**Notes**: Do NOT remove or broaden `RATE_LIMIT_PATTERN`. The check order is the fix: `error_max_turns` is semantically distinct from rate-limiting and must be matched first via parsed JSON, not regex.
+
+### T002: Add bounceContext module state + inject into buildClaudeArgs
+
+**File(s)**: `scripts/sdlc-runner.mjs` (module-state near line 148 `bounceCount`; `runStep` lines 2048-2080; `handleFailure` lines 1305-1318; `buildClaudeArgs` lines 931-1001; cycle-start reset in `main`)
+**Type**: Modify
+**Depends**: T001
+**Acceptance**:
+- [ ] `let bounceContext = null` declared at module scope alongside `bounceCount`.
+- [ ] Both bounce sites set `bounceContext = { from, fromStepNumber, reason, failedCheck, divergenceHints }` when `retry-previous` fires. `reason` is one of `'precondition_failed' | 'error_max_turns'`. `divergenceHints` includes at minimum `remoteCommitsSuperseded: <bool>` when the reason is divergence-related, derived from a quick `git log origin/HEAD..HEAD` probe.
+- [ ] `buildClaudeArgs` prepends a `## Bounce context` block (human-readable YAML-ish) to the step prompt **only** when `bounceContext` is non-null and `bounceContext.fromStepNumber === step.number + 1` (the current step is the one being bounced *to*).
+- [ ] `bounceContext` is cleared (`= null`) at the top of `runStep` when the current step completes successfully (returns `'ok'`) and at the start of each new cycle in `main`.
+- [ ] The injected block uses a stable, parseable shape so the receiving subagent can read it without guessing: `from:`, `reason:`, `failedCheck:`, `remoteCommitsSuperseded:`.
+
+**Notes**: Keep the probe cheap — the purpose is a hint, not a full diagnosis. A single `git` call is fine; don't loop over commits.
+
+### T003: Create skills/commit-push/ with SKILL.md + references
+
+**File(s)**:
+- `skills/commit-push/SKILL.md` *(create)*
+- `skills/commit-push/references/rebase-and-push.md` *(create — relocated from `skills/open-pr/references/pr-body.md` § 0; adds the force-with-lease branch)*
+- `skills/commit-push/references/version-bump-delegation.md` *(create — pointer to `skills/open-pr/references/version-bump.md`)*
+
+**Type**: Create
+**Depends**: None (parallel with T001/T002; integrates via T006)
+**Acceptance**:
+- [ ] `SKILL.md` frontmatter matches the plugin's convention: `name: commit-push`, `description` beginning with an imperative verb, `allowed-tools` including `Bash(git:*)`, `disable-model-invocation: true`, `model: haiku`, and a trigger list that maps to the runner's usage.
+- [ ] Workflow covers: Step 1 stage all changes; Step 2 resolve + apply version bump (pointer to `version-bump-delegation.md`); Step 3 conventional-commit commit; Step 4 fetch + ancestry check vs `origin/{base-branch}`; Step 5 rebase when local is behind; Step 6 push.
+- [ ] Step 6 push rules: (a) no remote tracking branch → `git push -u origin HEAD`; (b) tracking exists and fast-forward → `git push`; (c) tracking exists and local was rebased AND `.claude/unattended-mode` sentinel is present AND the `--force-with-lease=ref:expected-sha` check is safe → `git push --force-with-lease`; (d) tracking exists and local was rebased AND sentinel is absent → emit interactive prompt per existing interactive-mode convention.
+- [ ] "Safe lease" is defined: the expected-sha passed to `--force-with-lease` is the `origin/{branch}` SHA from the fetch that preceded the rebase; the push fails safely if the remote advanced between the fetch and the push.
+- [ ] SKILL.md reads `../../references/legacy-layout-gate.md` and `../../references/unattended-mode.md` at the top, per the plugin's convention.
+- [ ] `rebase-and-push.md` preserves the epic-child race-detection logic currently in `skills/open-pr/references/pr-body.md` § 0 (rebase, re-compute bump, `--amend`, conflict handling).
+- [ ] `version-bump-delegation.md` points at the existing bump matrix reference without duplicating content.
+
+**Notes**: Do NOT re-author the version-bump procedure — the existing `skills/open-pr/references/version-bump.md` is the source of truth. The commit-push skill references it.
+
+### T004: Trim /open-pr of version-bump + pre-push rebase
+
+**File(s)**:
+- `skills/open-pr/SKILL.md` (remove Steps 2, 3; modify Step 5)
+- `skills/open-pr/references/pr-body.md` (remove Section 0 pre-push race detection + Section 1 push rules)
+- `skills/open-pr/references/preflight.md` (re-scope to "PR-creation-only" preconditions if it currently mentions the bump)
+
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `open-pr/SKILL.md` workflow reads: Step 0 parse args → Step 1 read context → Step 4 generate PR content → Step 5 ancestry check + `gh pr create` → Step 6 output → Step 7 optional CI monitor. Steps 2 and 3 are removed.
+- [ ] The Step 5 ancestry check: `git merge-base --is-ancestor HEAD origin/main`. If non-zero, exit non-zero with stdout including the sentinel line `DIVERGED: re-run commit-push to reconcile before creating PR`. Do NOT rebase, do NOT push, do NOT amend.
+- [ ] `pr-body.md` Section 0 ("Pre-push race detection") and Section 1 ("Push") are removed. Section 2 (`gh pr create`) and the output block remain.
+- [ ] `preflight.md` no longer gates on "version bump precondition"; it gates only on "dirty tree" / "empty implementation branch" / "ancestry vs origin/main clean".
+- [ ] The `--major` escalation branch at the top of SKILL.md is unchanged (it already pre-dates commit creation and does not affect the push).
+- [ ] No new `--force` or `--force-with-lease` guidance remains in `/open-pr` references (the push duty has moved).
+
+**Notes**: The `Version` / `Bump:` lines in the PR body templates stay — they describe what `commit-push` committed. `/open-pr` reads them from `VERSION` / `CHANGELOG.md` when assembling Template A/B.
+
+### T005: Add stale-remote-branch probe to /start-issue
+
+**File(s)**:
+- `skills/start-issue/SKILL.md` (add Step 3.5)
+- `skills/start-issue/references/stale-remote-branch.md` *(create)*
+
+**Type**: Modify + Create
+**Depends**: None
+**Acceptance**:
+- [ ] SKILL.md inserts a "Step 3.5: Reconcile stale remote branch" between the existing Step 3 (confirm) and Step 4 (create branch). The step's entire procedure lives in the new reference; the SKILL.md body is one pointer line.
+- [ ] The reference documents: (a) derive the feature-branch name for issue N (first try `gh issue view N --json linkedBranches`, then fallback to the `{N}-{slug}` convention from `feature-naming.md`); (b) probe with `git ls-remote --heads origin {branch}`; (c) when the remote tip exists and `git merge-base --is-ancestor <remote-tip> origin/main` is non-zero, delete the stale branch via `git push origin --delete {branch}`; (d) log `"Reconciled stale remote branch {branch} (tip {sha} not ancestor of origin/main)"`.
+- [ ] The probe skips itself when no remote branch exists (green path — no log entry, no delete attempt).
+- [ ] The probe is gated by unattended mode: in interactive mode, it prompts via `AskUserQuestion` before deleting (two-option menu: delete and proceed / abort). In unattended mode per `references/unattended-mode.md` deterministic-default pattern, it deletes without prompting.
+- [ ] After probe success (delete or no-op), Step 4's existing `gh issue develop --checkout` proceeds unchanged.
+
+**Notes**: Use `git merge-base --is-ancestor <remote-tip> origin/main` (not `main` as a local ref) — the probe runs before Step 4, so main must be up-to-date via `git fetch origin` which the step performs.
+
+### T006: Wire runner prompt + config for commit-push skill; update skill-inventory baseline
+
+**File(s)**:
+- `scripts/sdlc-runner.mjs` (line 979 `commitPush` prompt; prompt table lookup)
+- `scripts/sdlc-config.example.json` (add `"skill": "commit-push"` to the `commitPush` step; note that `maxTurns: 15` likely stays but flag for T009 review)
+- `scripts/skill-inventory.baseline.json` (add `commit-push` entry)
+
+**Type**: Modify
+**Depends**: T003
+**Acceptance**:
+- [ ] `commitPush` prompt at line 979 becomes skill-backed and matches the pattern of `writeSpecs`, `implement`, `verify`, `createPR`: `"Commit and push the work for issue #{N} on branch {branch}. Skill instructions are appended to your system prompt. Resolve relative file references from {skillRoot}/."`
+- [ ] `sdlc-config.example.json` entry for `commitPush` includes `"skill": "commit-push"` so `resolveSkillsBase` can locate it.
+- [ ] `skill-inventory.baseline.json` includes `commit-push` with its expected file list; the audit script passes.
+- [ ] The runner does not attempt to read `skills/commit-push/SKILL.md` before T003 lands — T006 must merge after or with T003.
+
+**Notes**: Do NOT change `createPR`'s `maxTurns` default in this task; T009 handles FR6.
+
+### T007: Regression tests
+
+**File(s)**:
+- `scripts/__tests__/sdlc-runner.test.mjs` *(extend — new describe blocks)*
+- `scripts/__tests__/stale-remote-branch.test.mjs` *(create — if the probe helper is extractable)*
+
+**Type**: Create + Modify
+**Depends**: T001, T002, T005
+**Acceptance**:
+- [ ] New test: `matchErrorPattern` returns `{ action: 'max_turns' }` for a stream output containing `{"subtype":"error_max_turns"}` and does NOT match the rate-limit pattern in the same output.
+- [ ] New test: `handleFailure` invoked with an `error_max_turns` result does not call `sleep(60_000)` (mock `sleep`); asserts the bounce path is taken with no rate-limit log entry.
+- [ ] New test: `bounceContext` is non-null after a precondition bounce and is consumed by the next `buildClaudeArgs(step, state)` call where `step.number === bounceContext.fromStepNumber - 1`.
+- [ ] New test: `bounceContext` is `null` after the re-invoked step completes successfully.
+- [ ] New test: the stale-remote-branch probe's decision function (extract into a testable helper if needed) returns `'delete'` when the remote tip is not an ancestor of `origin/main` and `'skip'` when no remote branch exists. Use a temp repo with two disposable refs to exercise both paths.
+- [ ] Tests follow the project's existing jest-ESM pattern (see `sdlc-runner.test.mjs`).
+
+**Notes**: Do not land exercise-SDK tests (opt-in via `RUN_EXERCISE_TESTS=1`) — those are for the end-to-end verification step (T009). T007 covers deterministic unit-level regression guards.
+
+### T008: Write @regression Gherkin scenarios for all 8 ACs
+
+**File(s)**: `specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/feature.gherkin`
+**Type**: Create
+**Depends**: None (can run in parallel with implementation)
+**Acceptance**:
+- [ ] One `@regression`-tagged `Scenario:` per AC (AC1–AC8) — eight total.
+- [ ] `Feature:` description states what was broken (cascade failure on diverged remote under unattended mode) and how the fix addresses it.
+- [ ] Each scenario uses concrete data drawn from the issue reproduction (issue #249, branch `249-fix-config-init-custom-path`, etc.).
+- [ ] `Feature`-level `@regression` tag is present per the defect Gherkin convention.
+- [ ] Valid Gherkin syntax.
+
+### T009: End-to-end verification + re-evaluate createPR maxTurns (FR6)
+
+**File(s)**: None modified directly; this task is verification + potentially a config default tweak
+**Type**: Verify
+**Depends**: T001, T002, T003, T004, T005, T006, T007
+**Acceptance**:
+- [ ] Run the unattended runner on the three original reproducer sessions (or equivalent synthetic reproducers): (a) re-picked issue with stale remote branch; (b) main advances mid-run; (c) fresh green-path cycle. All three complete without escalation and produce a merged PR (or reach `monitorCI` on CI-less repos).
+- [ ] Capture actual `createPR` turn usage across three consecutive successful green-path runs. If the p95 is under 20, lower `sdlc-config.example.json` → `commitPush` and `createPR` defaults accordingly and note the evidence in `CHANGELOG.md` under `[Unreleased]`.
+- [ ] If the p95 stays between 20 and 45, keep the current defaults and document the decision in the PR body for issue #102.
+- [ ] Runner log for the stale-remote scenario contains: "Reconciled stale remote branch …" and does NOT contain "Rate limited" or "won't force-push without your confirmation".
+- [ ] Green-path log contains NONE of: "force-with-lease", "Reconciled stale remote branch", "Bounce context" — confirming AC8 no-regression.
+
+**Notes**: The FR6 re-evaluation is empirical; do not guess a new default without runner evidence. If the cycle time budget is too tight for three back-to-back runs, document the measurement plan and schedule it for the follow-up cycle rather than blocking the fix on it.
+
+---
+
+## Validation Checklist
+
+Before moving to IMPLEMENT phase:
+
+- [x] Tasks are focused on the six-defect fix — no feature work
+- [x] Regression test task is included (T007) + BDD scenarios (T008)
+- [x] Each task has verifiable acceptance criteria
+- [x] No scope creep beyond the defect
+- [x] File paths reference actual project structure (per `structure.md`)


### PR DESCRIPTION
## Summary

- Moves history reconciliation and push out of \`/open-pr\` into a new \`/commit-push\` skill, eliminating the cascade failure when a remote branch has diverged from \`origin/main\` mid-run
- Teaches the SDLC runner to distinguish \`error_max_turns\` from rate-limiting and threads structured bounce context between steps so the bounced-to subagent does not re-investigate divergence from scratch
- Adds stale-remote-branch detection to \`/start-issue\` (Step 3.5) so re-picked cycles automatically clean up stale remote tips before rebuilding local

## Acceptance Criteria

From \`specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/requirements.md\`:

- [ ] AC1: \`createPR\` does not non-force-push after rewriting history
- [ ] AC2: \`commitPush\` force-pushes with lease in unattended mode when safe
- [ ] AC3: Runner distinguishes \`error_max_turns\` from rate-limiting
- [ ] AC4: \`createPR\` is scoped to preconditions + \`gh pr create\` only
- [ ] AC5: Bounce transitions carry structured state (\`from\`, \`reason\`, \`failedCheck\`, \`remoteCommitsSuperseded\`)
- [ ] AC6: \`createPR\` budget fits its post-FR1 responsibilities
- [ ] AC7: \`startIssue\` reconciles stale remote branches before re-picked cycles
- [ ] AC8: No regression for the green-path cycle

## Test Plan

From \`specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/tasks.md\`:

- [ ] Unit: \`matchErrorPattern\` returns \`{ action: 'max_turns' }\` for \`error_max_turns\` stream output (before rate-limit regex)
- [ ] Unit: \`handleFailure\` with \`error_max_turns\` does not call \`sleep(60_000)\` and logs \`"Turn budget exhausted..."\` not \`"Rate limited"\`
- [ ] Unit: \`bounceContext\` is non-null after a precondition bounce and injected by \`buildClaudeArgs\` into the receiving step's prompt
- [ ] Unit: \`bounceContext\` is \`null\` after the bounced-to step completes successfully
- [ ] Unit: stale-remote-branch decision function returns \`'delete'\` for non-ancestor remote tip and \`'skip'\` when no remote branch exists

## Specs

- Requirements: \`specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/requirements.md\`
- Design: \`specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/design.md\`
- Tasks: \`specs/bug-fix-unattended-sdlc-runner-cascade-failure-on-diverged-remote-branch/tasks.md\`

Closes #102